### PR TITLE
enforce standard linting and fix issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7716,6 +7716,116 @@
         "lodash": "^4.17.10"
       }
     },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+      "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.27.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "tslint-config-standard": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-standard/-/tslint-config-standard-7.1.0.tgz",
+      "integrity": "sha512-cETzxZcEQ1RKjwtEScGryAtqwiRFc55xBxhZP6bePyOfXmo6i1/QKQrTgFKBiM4FjCvcqTjJq20/KGrh+TzTfQ==",
+      "dev": true,
+      "requires": {
+        "tslint-eslint-rules": "^5.3.1"
+      }
+    },
+    "tslint-eslint-rules": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.3.1.tgz",
+      "integrity": "sha512-qq2H/AU/FlFbQJKXuxhtIk+ni/nQu9jHHhsFKa6hnA0/n3zl1/RWRc3TVFlL8HfWFMzkST350VeTrFpy1u4OUg==",
+      "dev": true,
+      "requires": {
+        "doctrine": "0.7.2",
+        "tslib": "1.9.0",
+        "tsutils": "2.8.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+          "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+          "dev": true,
+          "requires": {
+            "esutils": "^1.1.6",
+            "isarray": "0.0.1"
+          }
+        },
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.0.tgz",
+          "integrity": "sha1-AWAXNymzvxOGKN0UoVN+AIUdgUo=",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.7.1"
+          }
+        }
+      }
+    },
+    "tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "build:watch": "tsc -p tsconfig.json --watch",
     "dev": "nodemon --exec \"npm start\"",
     "start": "probot run ./lib/index.js",
-    "lint": "standard --fix",
-    "test": "jest && standard",
+    "lint": "tslint --project . --fix",
+    "test": "jest && tslint --project .",
     "test:travis": "jest --coverage --coverageReporters=text-lcov | coveralls && standard",
     "test:watch": "jest --watch --notify --notifyMode=change --coverage",
     "heroku-postbuild": "npm run build"
@@ -39,6 +40,8 @@
     "smee-client": "^1.0.2",
     "standard": "^11.0.1",
     "ts-jest": "^23.1.3",
+    "tslint": "^5.11.0",
+    "tslint-config-standard": "^7.1.0",
     "typescript": "^3.0.1"
   },
   "engines": {

--- a/src/association.ts
+++ b/src/association.ts
@@ -1,4 +1,4 @@
-import { CommentAuthorAssociation } from "./github-models";
+import { CommentAuthorAssociation } from './github-models'
 
 export const associations: CommentAuthorAssociation[] = [
   'NONE',
@@ -10,8 +10,8 @@ export const associations: CommentAuthorAssociation[] = [
   'OWNER'
 ]
 
-export function getAssociationPriority(association: CommentAuthorAssociation): number {
+export function getAssociationPriority (association: CommentAuthorAssociation): number {
   // Note: this will return -1 for any association that is not found.
   // This will prioritise unknown associations lowest.
-  return associations.indexOf(association);
+  return associations.indexOf(association)
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,7 +40,7 @@ export const defaultConfig: Config = {
   requiredLabels: []
 }
 
-export async function loadConfig(context: Context): Promise<Config | null> {
+export async function loadConfig (context: Context): Promise<Config | null> {
   const config = await getConfig(context, 'auto-merge.yml', defaultConfig)
   return config && {
     ...defaultConfig,

--- a/src/github-models.ts
+++ b/src/github-models.ts
@@ -1,13 +1,13 @@
-import { ElementOf } from './utils';
+import { ElementOf } from './utils'
 export type PullRequestState = 'OPEN' | 'CLOSED' | 'MERGED'
 export type MergeableState = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
 export type CommentAuthorAssociation = 'MEMBER' | 'OWNER' | 'COLLABORATOR' | 'CONTRIBUTOR' | 'FIRST_TIME_CONTRIBUTOR' | 'FIRST_TIMER' | 'NONE'
 export type PullRequestReviewState = 'PENDING' | 'COMMENTED' | 'APPROVED' | 'CHANGES_REQUESTED' | 'DISMISSED'
 
 export interface PullRequestReference {
-  owner: string;
-  repo: string;
-  number: number;
+  owner: string
+  repo: string
+  number: number
 }
 
 export interface CheckRun {
@@ -86,4 +86,4 @@ export type PullRequestInfo = PullRequestQueryResult['repository']['pullRequest'
   checkRuns: CheckRun[]
 }
 
-export type Review = ElementOf<PullRequestInfo["reviews"]["nodes"]>
+export type Review = ElementOf<PullRequestInfo['reviews']['nodes']>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,3 @@
 declare module "probot-config" {
-  export default function getConfig<TContext, TConfig>(context: TContext, fileName: String, defaultConfig: TConfig): TConfig
+  export default function getConfig<TContext, TConfig>(context: TContext, fileName: String, defaultConfig: TConfig): Promise<TConfig>
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import { Application, Context } from 'probot'
 import { loadConfig } from './config'
 import { schedulePullRequestTrigger } from './pull-request-handler'
-import { HandlerContext } from './models';
+import { HandlerContext } from './models'
 
-async function getHandlerContext(options: {app: Application, context: Context}): Promise<HandlerContext | null> {
+async function getHandlerContext (options: {app: Application, context: Context}): Promise<HandlerContext | null> {
   const config = await loadConfig(options.context)
   return config && {
     config,
@@ -27,7 +27,7 @@ export = (app: Application) => {
   ], async context => {
     const handlerContext = await getHandlerContext({ app, context })
     if (!handlerContext) { return }
-    await schedulePullRequestTrigger(handlerContext, {
+    schedulePullRequestTrigger(handlerContext, {
       owner: context.payload.repository.owner.login,
       repo: context.payload.repository.name,
       number: context.payload.pull_request.number
@@ -41,8 +41,8 @@ export = (app: Application) => {
   ], async context => {
     const handlerContext = await getHandlerContext({ app, context })
     if (!handlerContext) { return }
-    for(const pullRequest of context.payload.check_run.pull_requests) {
-      await schedulePullRequestTrigger(handlerContext, {
+    for (const pullRequest of context.payload.check_run.pull_requests) {
+      schedulePullRequestTrigger(handlerContext, {
         owner: context.payload.repository.owner.login,
         repo: context.payload.repository.name,
         number: pullRequest.number
@@ -57,8 +57,8 @@ export = (app: Application) => {
   ], async context => {
     const handlerContext = await getHandlerContext({ app, context })
     if (!handlerContext) { return }
-    for(const pullRequest of context.payload.check_suite.pull_requests) {
-      await schedulePullRequestTrigger(handlerContext, {
+    for (const pullRequest of context.payload.check_suite.pull_requests) {
+      schedulePullRequestTrigger(handlerContext, {
         owner: context.payload.repository.owner.login,
         repo: context.payload.repository.name,
         number: pullRequest.number

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,10 +1,10 @@
-import { Context } from "probot";
-import { Config } from "./config";
+import { Context } from 'probot'
+import { Config } from './config'
 
 export interface HandlerContext {
-  log: (msg: string) => void;
-  github: Context["github"];
-  config: Config;
+  log: (msg: string) => void
+  github: Context['github']
+  config: Config
 }
 
 export * from './github-models'

--- a/src/pull-request-query.ts
+++ b/src/pull-request-query.ts
@@ -1,8 +1,8 @@
-import { PullRequestReference, CheckRun, PullRequestInfo, PullRequestQueryResult } from './github-models';
-import { Context } from "probot";
-import { result } from './utils';
+import { PullRequestReference, CheckRun, PullRequestInfo, PullRequestQueryResult } from './github-models'
+import { Context } from 'probot'
+import { result } from './utils'
 
-export async function queryPullRequest(github: Context['github'], { owner, repo, number }: PullRequestReference): Promise<PullRequestInfo> {
+export async function queryPullRequest (github: Context['github'], { owner, repo, number: pullRequestNumber }: PullRequestReference): Promise<PullRequestInfo> {
   const response = await github.query(`
     query PullRequestQuery($owner:String!, $repo:String!, $pullRequestNumber:Int!) {
       repository(owner: $owner, name: $repo) {
@@ -69,10 +69,10 @@ export async function queryPullRequest(github: Context['github'], { owner, repo,
   `, {
     'owner': owner,
     'repo': repo,
-    'pullRequestNumber': number
+    'pullRequestNumber': pullRequestNumber
   }) as any
   if (!response) {
-    throw new Error(`Could not query pull request ${owner}/${repo}#${number}`)
+    throw new Error(`Could not query pull request ${owner}/${repo}#${pullRequestNumber}`)
   }
   const queryResult = response as PullRequestQueryResult
 
@@ -80,7 +80,7 @@ export async function queryPullRequest(github: Context['github'], { owner, repo,
     owner: queryResult.repository.pullRequest.headRef.repository.owner.login,
     repo: queryResult.repository.pullRequest.headRef.repository.name,
     ref: queryResult.repository.pullRequest.headRef.name,
-    filter: "latest"
+    filter: 'latest'
   }))
 
   return {

--- a/src/pull-request-status.ts
+++ b/src/pull-request-status.ts
@@ -1,142 +1,142 @@
-import { HandlerContext, PullRequestInfo } from "./models";
-import { groupByLast, groupByLastMap } from "./utils";
-import { associations, getAssociationPriority } from "./association";
+import { HandlerContext, PullRequestInfo } from './models'
+import { groupByLast, groupByLastMap } from './utils'
+import { associations, getAssociationPriority } from './association'
 
 export type PullRequestStatus =
   | {
-      code:
-        | "merged"
-        | "closed"
-        | "not_open"
-        | "requires_label"
-        | "blocking_label"
-        | "pending_mergeable"
-        | "conflicts"
-        | "changes_requested"
-        | "need_approvals"
-        | "pending_checks"
-        | "blocking_check"
-        | "out_of_date_branch"
-        | "ready_for_merge";
-      message: string;
-    }
+    code:
+        | 'merged'
+        | 'closed'
+        | 'not_open'
+        | 'requires_label'
+        | 'blocking_label'
+        | 'pending_mergeable'
+        | 'conflicts'
+        | 'changes_requested'
+        | 'need_approvals'
+        | 'pending_checks'
+        | 'blocking_check'
+        | 'out_of_date_branch'
+        | 'ready_for_merge';
+    message: string;
+  }
 
-export type PullRequestStatusCode = PullRequestStatus["code"];
+export type PullRequestStatusCode = PullRequestStatus['code']
 
 export const PullRequestStatusCodes: PullRequestStatusCode[] = [
-  "merged",
-  "closed",
-  "not_open",
-  "pending_mergeable",
-  "conflicts",
-  "changes_requested",
-  "need_approvals",
-  "pending_checks",
-  "blocking_check",
-  "out_of_date_branch",
-  "ready_for_merge"
-];
+  'merged',
+  'closed',
+  'not_open',
+  'pending_mergeable',
+  'conflicts',
+  'changes_requested',
+  'need_approvals',
+  'pending_checks',
+  'blocking_check',
+  'out_of_date_branch',
+  'ready_for_merge'
+]
 
-function getPullRequestStatusFromPullRequest(
+function getPullRequestStatusFromPullRequest (
   context: HandlerContext,
   pullRequestInfo: PullRequestInfo
 ): PullRequestStatus | null {
   switch (pullRequestInfo.state) {
     case 'CLOSED':
       return {
-        code: "closed",
-        message: "Pull request is closed"
-      };
+        code: 'closed',
+        message: 'Pull request is closed'
+      }
     case 'MERGED':
       return {
-        code: "merged",
-        message: "Pull request was already merged"
-      };
+        code: 'merged',
+        message: 'Pull request was already merged'
+      }
     default:
       return {
-        code: "not_open",
-        message: "Pull request is not open"
-      };
+        code: 'not_open',
+        message: 'Pull request is not open'
+      }
     case 'OPEN':
       // Continue.
-      break;
+      break
   }
 
   switch (pullRequestInfo.mergeable) {
     case 'CONFLICTING':
       return {
-        code: "conflicts",
-        message: "Could not merge pull request due to conflicts"
-      };
+        code: 'conflicts',
+        message: 'Could not merge pull request due to conflicts'
+      }
     case 'UNKNOWN':
       return {
-        code: "pending_mergeable",
-        message: "Mergeablity of pull request could not yet be determined"
-      };
+        code: 'pending_mergeable',
+        message: 'Mergeablity of pull request could not yet be determined'
+      }
     case 'MERGEABLE':
       // Continue.
-      break;
+      break
   }
-  return null;
+  return null
 }
 
-function getPullRequestStatusFromLabels(
+function getPullRequestStatusFromLabels (
   context: HandlerContext,
   pullRequestInfo: PullRequestInfo
 ): PullRequestStatus | null {
-  const { config } = context;
-  function hasLabel(labelName: string): boolean {
-    return pullRequestInfo.labels.nodes.some(label => label.name === labelName);
+  const { config } = context
+  function hasLabel (labelName: string): boolean {
+    return pullRequestInfo.labels.nodes.some(label => label.name === labelName)
   }
 
   const missingRequiredLabels = config.requiredLabels.filter(
     requiredLabel => !hasLabel(requiredLabel)
-  );
+  )
   if (missingRequiredLabels.length > 0) {
     return {
-      code: "requires_label",
+      code: 'requires_label',
       message: `Required labels are missing (${missingRequiredLabels.join(
-        ", "
+        ', '
       )})`
-    };
+    }
   }
 
   const matchingBlockingLabels = config.blockingLabels.filter(
     blockingLabel => hasLabel(blockingLabel)
-  );
+  )
   if (matchingBlockingLabels.length > 0) {
     return {
-      code: "blocking_label",
+      code: 'blocking_label',
       message: `Blocking labels were added to the pull request (${
-        matchingBlockingLabels.join(", ")
+        matchingBlockingLabels.join(', ')
       })`
-    };
+    }
   }
 
   return null
 }
 
-function getPullRequestStatusFromReviews(
+function getPullRequestStatusFromReviews (
   context: HandlerContext,
   pullRequestInfo: PullRequestInfo
 ): PullRequestStatus | null {
-  const { config, log } = context;
+  const { config, log } = context
   const sortedReviews = pullRequestInfo.reviews.nodes.sort(
     (a, b) =>
       new Date(a.submittedAt).getTime() - new Date(b.submittedAt).getTime()
-  );
+  )
   const latestReviewsByUser = groupByLast(
     review => review.author.login,
     sortedReviews
-  );
+  )
 
   const reviewSummary = Object.entries(latestReviewsByUser)
     .map(([user, review]) => `${user}: ${review.state}`)
-    .join("\n");
+    .join('\n')
 
-  log(`\nReviews:\n${reviewSummary}\n\n`);
+  log(`\nReviews:\n${reviewSummary}\n\n`)
 
-  const latestReviews = Object.values(latestReviewsByUser);
+  const latestReviews = Object.values(latestReviewsByUser)
 
   let approvedByOneAssociation = false
   for (let association of associations) {
@@ -146,98 +146,97 @@ function getPullRequestStatusFromReviews(
     const maxRequestedChanges = config.maxRequestedChanges[association]
     if (maxRequestedChanges !== undefined && changesRequestedCount > maxRequestedChanges) {
       return {
-        code: "changes_requested",
+        code: 'changes_requested',
         message: `There are changes requested by a reviewer.`
-      };
+      }
     }
 
     const approvalCount = associationReviews.filter(review => review.state === 'APPROVED').length
     const minApprovals = config.minApprovals[association]
     if (minApprovals !== undefined && approvalCount >= minApprovals) {
-      approvedByOneAssociation = true;
+      approvedByOneAssociation = true
     }
   }
 
   if (approvedByOneAssociation) {
-    return null;
+    return null
   } else {
     return {
-      code: "need_approvals",
+      code: 'need_approvals',
       message: `There are not enough approvals by reviewers`
-    };
+    }
   }
 }
 
-function getPullRequestStatusFromChecks(
+function getPullRequestStatusFromChecks (
   context: HandlerContext,
   pullRequestInfo: PullRequestInfo
 ): PullRequestStatus | null {
-  const { log } = context;
-  const checkRuns = pullRequestInfo.checkRuns;
+  const { log } = context
+  const checkRuns = pullRequestInfo.checkRuns
   // log('checks: ' + JSON.stringify(checks))
   const checksSummary = checkRuns
     .map(
       checkRun => `${checkRun.name}: ${checkRun.status}: ${checkRun.conclusion}`
     )
-    .join("\n");
+    .join('\n')
 
-  log(`\nChecks:\n${checksSummary}\n\n`);
+  log(`\nChecks:\n${checksSummary}\n\n`)
 
   const allChecksCompleted = checkRuns.every(
-    checkRun => checkRun.status === "completed"
-  );
+    checkRun => checkRun.status === 'completed'
+  )
   if (!allChecksCompleted) {
     return {
-      code: "pending_checks",
-      message: "There are still pending checks"
-    };
+      code: 'pending_checks',
+      message: 'There are still pending checks'
+    }
   }
   const checkConclusions = groupByLastMap(
     checkRun => checkRun.conclusion,
     _ => true,
     checkRuns
-  );
-  log("conclusions: " + JSON.stringify(checkConclusions));
+  )
+  log('conclusions: ' + JSON.stringify(checkConclusions))
   const checksBlocking =
     checkConclusions.failure ||
     checkConclusions.cancelled ||
     checkConclusions.timed_out ||
-    checkConclusions.action_required;
+    checkConclusions.action_required
   if (checksBlocking) {
     return {
-      code: "blocking_check",
-      message: "There are blocking checks"
-    };
+      code: 'blocking_check',
+      message: 'There are blocking checks'
+    }
   }
 
-  return null;
+  return null
 }
 
-function getPullRequestStatusFromProtectedBranch(
+function getPullRequestStatusFromProtectedBranch (
   context: HandlerContext,
   pullRequestInfo: PullRequestInfo
 ): PullRequestStatus | null {
   const protectedBranch = pullRequestInfo.repository.protectedBranches.nodes
-    .filter(protectedBranch => protectedBranch.name === pullRequestInfo.baseRef.name)
-    [0]
+    .filter(protectedBranch => protectedBranch.name === pullRequestInfo.baseRef.name)[0]
 
-  if (protectedBranch !== undefined
+  if (protectedBranch
     && protectedBranch.hasStrictRequiredStatusChecks
     && pullRequestInfo.baseRef.target.oid !== pullRequestInfo.baseRefOid) {
     return {
-      code: "out_of_date_branch",
+      code: 'out_of_date_branch',
       message: `Pull request is based on a strict protected branch (${
         pullRequestInfo.baseRef.name
       }) and base sha of pull request (${
         pullRequestInfo.baseRefOid
       }) differs from sha of branch (${pullRequestInfo.baseRef.target.oid})`
-    };
+    }
   }
 
-  return null;
+  return null
 }
 
-export async function getPullRequestStatus(
+export async function getPullRequestStatus (
   context: HandlerContext,
   pullRequestInfo: PullRequestInfo
 ): Promise<PullRequestStatus> {
@@ -247,8 +246,8 @@ export async function getPullRequestStatus(
     getPullRequestStatusFromReviews(context, pullRequestInfo) ||
     getPullRequestStatusFromChecks(context, pullRequestInfo) ||
     getPullRequestStatusFromProtectedBranch(context, pullRequestInfo) || {
-      code: "ready_for_merge",
-      message: "Pull request successfully merged"
+      code: 'ready_for_merge',
+      message: 'Pull request successfully merged'
     }
-  );
+  )
 }

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -15,7 +15,7 @@ export class TaskScheduler<TTask> {
   /**
    * Creates a TaskScheduler that handles tasks using the specified worker.
    */
-  constructor(opts: {
+  constructor (opts: {
     worker: TaskWorker<TTask>,
     concurrency?: number
   }) {
@@ -26,18 +26,18 @@ export class TaskScheduler<TTask> {
     })
   }
 
-  onIdle() {
+  onIdle () {
     return this.workerQueue.onIdle()
   }
 
-  stop() {
+  stop () {
     this.queues = {}
   }
 
   /**
    * Queue a task onto the queue with queueName
    */
-  queue(queueName: string, task: TTask) {
+  queue (queueName: string, task: TTask) {
     const queue = this.queues[queueName]
     if (queue) {
       queue.push(task)
@@ -47,12 +47,12 @@ export class TaskScheduler<TTask> {
     }
   }
 
-  hasQueued(queueName: string) {
+  hasQueued (queueName: string) {
     const queue = this.queues[queueName]
     return queue && queue.length > 0
   }
 
-  private async doWorkForKey(queueName: string) {
+  private async doWorkForKey (queueName: string) {
     debug(`doWorkForKey(${queueName})`)
     const queue = this.queues[queueName]
     if (!queue || queue.length === 0) {
@@ -82,7 +82,13 @@ export class TaskScheduler<TTask> {
     }
   }
 
-  private queueWorkForQueueName(queueName: string) {
+  private queueWorkForQueueName (queueName: string) {
     this.workerQueue.add(this.doWorkForKey.bind(this, queueName))
+      .then(() => {
+        // Task succeeded.
+        debug(`${queueName}: task succeeded`)
+      }, (err) => {
+        debug(`${queueName}: task failed`, err)
+      })
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,11 @@
-import { AnyResponse } from "@octokit/rest";
+import { AnyResponse } from '@octokit/rest'
 
-export type DeepPartial<T> = { [Key in keyof T]?: DeepPartial<T[Key]>; };
-export type ElementOf<TArray> = TArray extends Array<infer TElement> ? TElement : never;
+export type DeepPartial<T> = { [Key in keyof T]?: DeepPartial<T[Key]>; }
+export type ElementOf<TArray> = TArray extends Array<infer TElement> ? TElement : never
 
-export function identity<T>(v: T): T { return v; }
+export function identity<T> (v: T): T { return v }
 
-export function groupBy<TItem>(
+export function groupBy<TItem> (
   keyFn: (item: TItem) => string,
   list: TItem[]
 ): { [key: string]: TItem[] } {
@@ -20,14 +20,14 @@ export function groupBy<TItem>(
   }, {})
 }
 
-export function groupByLast<TItem>(
+export function groupByLast<TItem> (
   keyFn: (item: TItem) => string,
   list: TItem[]
 ): { [key: string]: TItem } {
   return groupByLastMap(keyFn, identity, list)
 }
 
-export function groupByLastMap<TItem, TValue>(
+export function groupByLastMap<TItem, TValue> (
   keyFn: (item: TItem) => string,
   valueFn: (item: TItem) => TValue,
   list: TItem[]
@@ -43,9 +43,9 @@ export function groupByLastMap<TItem, TValue>(
  * supplied type.
  * @param response The response from a GitHub API
  */
-export function result<TResult = void>(response: AnyResponse): TResult {
+export function result<TResult = void> (response: AnyResponse): TResult {
   if (response.status < 200 || response.status >= 300) {
-    throw new Error(`Response status was ${response.status}`);
+    throw new Error(`Response status was ${response.status}`)
   }
-  return response.data;
+  return response.data
 }

--- a/test/pull-request-query.test.ts
+++ b/test/pull-request-query.test.ts
@@ -1,8 +1,8 @@
-import { queryPullRequest } from "../src/pull-request-query";
-import { createGithubApi, createPullRequestInfo } from "./mock";
+import { queryPullRequest } from '../src/pull-request-query'
+import { createGithubApi, createPullRequestInfo } from './mock'
 
-describe("queryPullRequest", () => {
-  it("should do a single graphql query", async () => {
+describe('queryPullRequest', () => {
+  it('should do a single graphql query', async () => {
     const pullRequestInfo = createPullRequestInfo()
     const query = jest.fn(() => ({
       repository: {
@@ -24,8 +24,8 @@ describe("queryPullRequest", () => {
           listForRef
         }
       }),
-      { owner: "bobvanderlinden", repo: "probot-auto-merge", number: 1 }
-    );
-    expect(query).toHaveBeenCalledTimes(1);
+      { owner: 'bobvanderlinden', repo: 'probot-auto-merge', number: 1 }
+    )
+    expect(query).toHaveBeenCalledTimes(1)
   })
 })

--- a/test/task-scheduler.test.ts
+++ b/test/task-scheduler.test.ts
@@ -59,4 +59,3 @@ describe('TaskScheduler', () => {
     ])
   })
 })
-


### PR DESCRIPTION
Probot uses `standard` for linting by default. However the initial setup did not
actually support TypeScript properly. Thus linting did not work.

This PR will add `tslint` and use the `standard` configuration for `tslint`.

In addition, all files had their format automatically (and manually) fixed.