### PR TITLE
fix unintentionally skipping relevant tasks

### DIFF
--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -27,12 +27,20 @@ const pullRequestTimeouts: {
   [key: string]: NodeJS.Timer;
 } = {}
 
+export function arePullRequestReferencesEqual (a: PullRequestReference, b: PullRequestReference) {
+  return a.number === b.number
+    && a.owner === b.owner
+    && a.repo === b.owner
+}
+
 export function schedulePullRequestTrigger (
   context: HandlerContext,
   PullRequestReference: PullRequestReference
 ) {
   const queueName = getRepositoryKey(PullRequestReference)
-  if (!taskScheduler.hasQueued(queueName)) {
+  const queueContainsTask = taskScheduler.getQueue(queueName)
+    .some(task => arePullRequestReferencesEqual(task.PullRequestReference, PullRequestReference))
+  if (!queueContainsTask) {
     taskScheduler.queue(queueName, { context, PullRequestReference })
   }
 }

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -61,6 +61,10 @@ export class TaskScheduler<TTask> {
     return queue && queue.length > 0
   }
 
+  getQueue (queueName: string): TTask[] {
+    return this.queues[queueName] || []
+  }
+
   private async doWorkForKey (queueName: string) {
     debug(`doWorkForKey(${queueName})`)
     const queue = this.queues[queueName]


### PR DESCRIPTION
Previously auto-merge checked whether a queue exists for a PR. Queues were made
per repository, so it was checking whether another task of the same repository was
already running. Other PR triggers of the same repository would be skipped.

This PR will fix the behavior to only skip when the PR task is not yet in the queue
of the repository.