### PR TITLE
schedule a recheck for pending mergability

### DIFF
--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -156,6 +156,7 @@ export async function handlePullRequestStatus (
         }))
       }
       return
+    case 'pending_mergeable':
     case 'pending_checks':
       // Some checks (like Travis) seem to not always send
       // their status updates. Making this process being stalled.


### PR DESCRIPTION
Sometimes GitHub responds with `mergeability: unknown`. That means GitHub still needs to determine whether the PR is indeed mergeable.
However, GitHub doesn't notify us with a new message on the PR that the mergeability has changed from unkown to mergeable or conflicting.

This is why we need a similar mechanism as we're using for the checks api.