### PR TITLE
Disable email notifications for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ language: node_js
 node_js:
   - "8.3"
 notifications:
-  disabled: true
+  email: false
 script:
   - npm run test:travis


### PR DESCRIPTION
At the moment all notifications for travis are disabled, but I only care about Travis not spamming me with emails.
In addition, the Travis linter said `disabled: true` was incorrect.