### PR TITLE
Add support for multiple rules

### DIFF
--- a/src/condition.ts
+++ b/src/condition.ts
@@ -1,4 +1,5 @@
-import { HandlerContext, PullRequestInfo } from './models'
+import { ConditionConfig } from './config'
+import { PullRequestInfo } from './models'
 
-export type Condition = (context: HandlerContext, pullRequestInfo: PullRequestInfo) => ConditionResult
+export type Condition = (config: ConditionConfig, pullRequestInfo: PullRequestInfo) => ConditionResult
 export type ConditionResult = { status: 'success' } | { status: 'fail', message: string } | { status: 'pending', message?: string }

--- a/src/conditions/blockingChecks.ts
+++ b/src/conditions/blockingChecks.ts
@@ -1,9 +1,10 @@
-import { HandlerContext, PullRequestInfo } from '../models'
+import { ConditionConfig } from './../config'
+import { PullRequestInfo } from '../models'
 import { ConditionResult } from '../condition'
 import { groupByLastMap } from '../utils'
 
 export default function doesNotHaveBlockingChecks (
-  context: HandlerContext,
+  config: ConditionConfig,
   pullRequestInfo: PullRequestInfo
 ): ConditionResult {
   const checkRuns = pullRequestInfo.checkRuns

--- a/src/conditions/blockingLabels.ts
+++ b/src/conditions/blockingLabels.ts
@@ -1,11 +1,11 @@
-import { HandlerContext, PullRequestInfo } from '../models'
+import { ConditionConfig } from './../config'
+import { PullRequestInfo } from '../models'
 import { ConditionResult } from '../condition'
 
 export default function doesNotHaveBlockingLabels (
-  context: HandlerContext,
+  config: ConditionConfig,
   pullRequestInfo: PullRequestInfo
 ): ConditionResult {
-  const { config } = context
   const pullRequestLabels = new Set(pullRequestInfo.labels.nodes.map(label => label.name))
   const foundBlockingLabels = config.blockingLabels
     .filter(blockingLabel => pullRequestLabels.has(blockingLabel))

--- a/src/conditions/index.ts
+++ b/src/conditions/index.ts
@@ -19,6 +19,8 @@ export const conditions = {
   blockingChecks,
   upToDateBranch
 }
+
+export type Conditions = typeof conditions
 export const conditionNames: ConditionName[] = keysOf<ConditionName>(conditions)
 export type ConditionName = keyof (typeof conditions)
 export type ConditionResults = { [key in ConditionName]: ConditionResult }

--- a/src/conditions/maximumChangesRequested.ts
+++ b/src/conditions/maximumChangesRequested.ts
@@ -1,11 +1,13 @@
-import { HandlerContext, PullRequestInfo } from '../models'
+import { ConditionConfig } from './../config'
+import { PullRequestInfo } from '../models'
 import { ConditionResult } from '../condition'
 import { getLatestReviews, arrayToMap, mapToArray, or, get } from '../utils'
 import { associations, getAssociationPriority } from '../association'
 
-export default function doesNotHaveMaximumChangesRequested (context: HandlerContext, pullRequestInfo: PullRequestInfo): ConditionResult {
-  const { config } = context
-
+export default function doesNotHaveMaximumChangesRequested (
+  config: ConditionConfig,
+  pullRequestInfo: PullRequestInfo
+): ConditionResult {
   const latestReviews = getLatestReviews(pullRequestInfo)
   const changesRequestedCountByAssociation =
     arrayToMap(associations,

--- a/src/conditions/mergeable.ts
+++ b/src/conditions/mergeable.ts
@@ -1,7 +1,11 @@
-import { HandlerContext, PullRequestInfo } from '../models'
+import { ConditionConfig } from './../config'
+import { PullRequestInfo } from '../models'
 import { ConditionResult } from '../condition'
 
-export default function isMergeable (context: HandlerContext, pullRequestInfo: PullRequestInfo): ConditionResult {
+export default function isMergeable (
+  config: ConditionConfig,
+  pullRequestInfo: PullRequestInfo
+): ConditionResult {
   switch (pullRequestInfo.mergeable) {
     case 'MERGEABLE':
       return {

--- a/src/conditions/minimumApprovals.ts
+++ b/src/conditions/minimumApprovals.ts
@@ -1,11 +1,13 @@
-import { HandlerContext, PullRequestInfo } from '../models'
+import { ConditionConfig } from './../config'
+import { PullRequestInfo } from '../models'
 import { ConditionResult } from '../condition'
 import { getLatestReviews, arrayToMap, or, get, mapToArray } from '../utils'
 import { associations, getAssociationPriority } from '../association'
 
-export default function hasMinimumApprovals (context: HandlerContext, pullRequestInfo: PullRequestInfo): ConditionResult {
-  const { config } = context
-
+export default function hasMinimumApprovals (
+  config: ConditionConfig,
+  pullRequestInfo: PullRequestInfo
+): ConditionResult {
   const latestReviews = getLatestReviews(pullRequestInfo)
   const approvalCountByAssociation =
     arrayToMap(associations,

--- a/src/conditions/open.ts
+++ b/src/conditions/open.ts
@@ -1,7 +1,11 @@
-import { HandlerContext, PullRequestInfo } from '../models'
+import { ConditionConfig } from './../config'
+import { PullRequestInfo } from '../models'
 import { ConditionResult } from '../condition'
 
-export default function isOpen (context: HandlerContext, pullRequestInfo: PullRequestInfo): ConditionResult {
+export default function isOpen (
+  config: ConditionConfig,
+  pullRequestInfo: PullRequestInfo
+): ConditionResult {
   return pullRequestInfo.state === 'OPEN'
     ? {
       status: 'success'

--- a/src/conditions/requiredLabels.ts
+++ b/src/conditions/requiredLabels.ts
@@ -1,11 +1,11 @@
-import { HandlerContext, PullRequestInfo } from '../models'
+import { ConditionConfig } from './../config'
+import { PullRequestInfo } from '../models'
 import { ConditionResult } from '../condition'
 
 export default function hasRequiredLabels (
-  context: HandlerContext,
+  config: ConditionConfig,
   pullRequestInfo: PullRequestInfo
 ): ConditionResult {
-  const { config } = context
   const pullRequestLabels = new Set(pullRequestInfo.labels.nodes.map(label => label.name))
 
   const missingRequiredLabels = config.requiredLabels

--- a/src/conditions/upToDateBranch.ts
+++ b/src/conditions/upToDateBranch.ts
@@ -1,8 +1,9 @@
-import { HandlerContext, PullRequestInfo } from '../models'
+import { ConditionConfig } from './../config'
+import { PullRequestInfo } from '../models'
 import { ConditionResult } from '../condition'
 
 export default function hasUpToDateBranch (
-  context: HandlerContext,
+  config: ConditionConfig,
   pullRequestInfo: PullRequestInfo
 ): ConditionResult {
   const protectedBranch = pullRequestInfo.repository.protectedBranches.nodes

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,27 +2,35 @@ import { CommentAuthorAssociation } from './github-models'
 import { Context } from 'probot'
 import getConfig from 'probot-config'
 
-export type Config = {
+export type ConditionConfig = {
   minApprovals: { [key in CommentAuthorAssociation]?: number },
   maxRequestedChanges: { [key in CommentAuthorAssociation]?: number },
-  updateBranch: boolean,
-  deleteBranchAfterMerge: boolean,
-  mergeMethod: 'merge' | 'rebase' | 'squash',
   requiredLabels: string[],
   blockingLabels: string[]
 }
 
-export const defaultConfig: Config = {
+export type Config = {
+  updateBranch: boolean,
+  deleteBranchAfterMerge: boolean,
+  mergeMethod: 'merge' | 'rebase' | 'squash'
+} & ConditionConfig
+
+export const defaultRuleConfig: ConditionConfig = {
   minApprovals: {
   },
   maxRequestedChanges: {
     NONE: 0
   },
+  blockingLabels: [],
+  requiredLabels: []
+}
+
+export const defaultConfig: Config = {
+  rules: [],
   updateBranch: false,
   deleteBranchAfterMerge: false,
   mergeMethod: 'merge',
-  blockingLabels: [],
-  requiredLabels: []
+  ...defaultRuleConfig
 }
 
 export async function loadConfig (context: Context): Promise<Config | null> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ export type ConditionConfig = {
 }
 
 export type Config = {
+  rules?: ConditionConfig[],
   updateBranch: boolean,
   deleteBranchAfterMerge: boolean,
   mergeMethod: 'merge' | 'rebase' | 'squash'

--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -1,3 +1,4 @@
+import { conditions } from './conditions/index'
 import Raven from 'raven'
 import { TaskScheduler } from './task-scheduler'
 import { HandlerContext, PullRequestReference, PullRequestInfo } from './models'
@@ -102,6 +103,7 @@ async function doPullRequestWork (
 
   const pullRequestStatus = getPullRequestStatus(
     context,
+    conditions,
     pullRequestInfo
   )
 

--- a/src/pull-request-status.ts
+++ b/src/pull-request-status.ts
@@ -2,13 +2,14 @@ import { ConditionConfig } from './config'
 import { HandlerContext, PullRequestInfo } from './models'
 import { ConditionResult, Condition } from './condition'
 
-import { conditions, ConditionResults, ConditionName } from './conditions/'
+import { Conditions, ConditionResults, ConditionName } from './conditions/'
 import { mapObject } from './utils'
 
 export type PullRequestStatus = ConditionResults
 
 export function getConditionResults (
   config: ConditionConfig,
+  conditions: Conditions,
   pullRequestInfo: PullRequestInfo
 ): ConditionResults {
   return mapObject<ConditionName, Condition, ConditionResult>(
@@ -19,6 +20,7 @@ export function getConditionResults (
 
 export function getPullRequestStatus (
   context: HandlerContext,
+  conditions: Conditions,
   pullRequestInfo: PullRequestInfo
 ): PullRequestStatus {
   return getConditionResults(context.config, pullRequestInfo)

--- a/src/pull-request-status.ts
+++ b/src/pull-request-status.ts
@@ -1,3 +1,4 @@
+import { ConditionConfig } from './config'
 import { HandlerContext, PullRequestInfo } from './models'
 import { ConditionResult, Condition } from './condition'
 
@@ -7,12 +8,12 @@ import { mapObject } from './utils'
 export type PullRequestStatus = ConditionResults
 
 export function getConditionResults (
-  context: HandlerContext,
+  config: ConditionConfig,
   pullRequestInfo: PullRequestInfo
 ): ConditionResults {
   return mapObject<ConditionName, Condition, ConditionResult>(
     conditions,
-    (condition: Condition) => condition(context, pullRequestInfo)
+    (condition: Condition) => condition(config, pullRequestInfo)
   )
 }
 
@@ -20,5 +21,5 @@ export function getPullRequestStatus (
   context: HandlerContext,
   pullRequestInfo: PullRequestInfo
 ): PullRequestStatus {
-  return getConditionResults(context, pullRequestInfo)
+  return getConditionResults(context.config, pullRequestInfo)
 }

--- a/test/conditions/blockingLabels.test.ts
+++ b/test/conditions/blockingLabels.test.ts
@@ -1,12 +1,10 @@
 import blockingLabels from '../../src/conditions/blockingLabels'
-import { createHandlerContext, createPullRequestInfo, createConfig } from '../mock'
+import { createPullRequestInfo, createConfig } from '../mock'
 
 describe('blockingLabels', () => {
   it('returns success with no labels and no configuration', async () => {
     const result = blockingLabels(
-      createHandlerContext({
-        config: createConfig()
-      }),
+      createConfig(),
       createPullRequestInfo({
         labels: {
           nodes: []
@@ -18,10 +16,8 @@ describe('blockingLabels', () => {
 
   it('returns success with label not in configuration', async () => {
     const result = blockingLabels(
-      createHandlerContext({
-        config: createConfig({
-          blockingLabels: ['blocking label']
-        })
+      createConfig({
+        blockingLabels: ['blocking label']
       }),
       createPullRequestInfo({
         labels: {
@@ -36,10 +32,8 @@ describe('blockingLabels', () => {
 
   it('returns fail with label in configuration', async () => {
     const result = blockingLabels(
-      createHandlerContext({
-        config: createConfig({
-          blockingLabels: ['blocking label']
-        })
+      createConfig({
+        blockingLabels: ['blocking label']
       }),
       createPullRequestInfo({
         labels: {
@@ -54,10 +48,8 @@ describe('blockingLabels', () => {
 
   it('returns fail with label, among others, in configuration', async () => {
     const result = blockingLabels(
-      createHandlerContext({
-        config: createConfig({
-          blockingLabels: ['blocking label']
-        })
+      createConfig({
+        blockingLabels: ['blocking label']
       }),
       createPullRequestInfo({
         labels: {

--- a/test/conditions/maximumChangesRequested.test.ts
+++ b/test/conditions/maximumChangesRequested.test.ts
@@ -1,12 +1,10 @@
 import doesNotHaveMaximumChangesRequested from '../../src/conditions/maximumChangesRequested'
-import { createHandlerContext, createConfig, createPullRequestInfo, approvedReview, changesRequestedReview } from '../mock'
+import { createConfig, createPullRequestInfo, approvedReview, changesRequestedReview } from '../mock'
 
 describe('maximumChangesRequested', () => {
   it('returns success when owner approved and nothing was configured', async () => {
     const result = doesNotHaveMaximumChangesRequested(
-      createHandlerContext({
-        config: createConfig()
-      }),
+      createConfig(),
       createPullRequestInfo({
         reviews: {
           nodes: [
@@ -20,12 +18,10 @@ describe('maximumChangesRequested', () => {
 
   it('returns fail when owner requested changes and none role has 0 maximum requested changes', async () => {
     const result = doesNotHaveMaximumChangesRequested(
-      createHandlerContext({
-        config: createConfig({
-          maxRequestedChanges: {
-            NONE: 0
-          }
-        })
+      createConfig({
+        maxRequestedChanges: {
+          NONE: 0
+        }
       }),
       createPullRequestInfo({
         reviews: {
@@ -40,12 +36,10 @@ describe('maximumChangesRequested', () => {
 
   it('returns fail when owner requested changes and owner role has 0 maximum requested changes', async () => {
     const result = doesNotHaveMaximumChangesRequested(
-      createHandlerContext({
-        config: createConfig({
-          maxRequestedChanges: {
-            OWNER: 0
-          }
-        })
+      createConfig({
+        maxRequestedChanges: {
+          OWNER: 0
+        }
       }),
       createPullRequestInfo({
         reviews: {
@@ -60,12 +54,10 @@ describe('maximumChangesRequested', () => {
 
   it('returns success when member requested changes but owner role has 0 maximum requested changes', async () => {
     const result = doesNotHaveMaximumChangesRequested(
-      createHandlerContext({
-        config: createConfig({
-          maxRequestedChanges: {
-            OWNER: 0
-          }
-        })
+      createConfig({
+        maxRequestedChanges: {
+          OWNER: 0
+        }
       }),
       createPullRequestInfo({
         reviews: {

--- a/test/conditions/minimumApprovals.test.ts
+++ b/test/conditions/minimumApprovals.test.ts
@@ -1,15 +1,13 @@
 import hasMinimumApprovals from '../../src/conditions/minimumApprovals'
-import { createHandlerContext, createConfig, createPullRequestInfo, approvedReview } from '../mock'
+import { createConfig, createPullRequestInfo, approvedReview } from '../mock'
 
 describe('minimumApprovals', () => {
   it('returns success when owner approved and owner was configured', async () => {
     const result = hasMinimumApprovals(
-      createHandlerContext({
-        config: createConfig({
-          minApprovals: {
-            OWNER: 1
-          }
-        })
+      createConfig({
+        minApprovals: {
+          OWNER: 1
+        }
       }),
       createPullRequestInfo({
         reviews: {
@@ -24,12 +22,10 @@ describe('minimumApprovals', () => {
 
   it('returns fail when member approved but owner was configured', async () => {
     const result = hasMinimumApprovals(
-      createHandlerContext({
-        config: createConfig({
-          minApprovals: {
-            OWNER: 1
-          }
-        })
+      createConfig({
+        minApprovals: {
+          OWNER: 1
+        }
       }),
       createPullRequestInfo({
         reviews: {
@@ -44,12 +40,10 @@ describe('minimumApprovals', () => {
 
   it('returns success when owner approved and member was configured', async () => {
     const result = hasMinimumApprovals(
-      createHandlerContext({
-        config: createConfig({
-          minApprovals: {
-            MEMBER: 1
-          }
-        })
+      createConfig({
+        minApprovals: {
+          MEMBER: 1
+        }
       }),
       createPullRequestInfo({
         reviews: {
@@ -64,9 +58,7 @@ describe('minimumApprovals', () => {
 
   it('returns success when owner approved but nothing was configured', async () => {
     const result = hasMinimumApprovals(
-      createHandlerContext({
-        config: createConfig()
-      }),
+      createConfig(),
       createPullRequestInfo({
         reviews: {
           nodes: [
@@ -80,12 +72,10 @@ describe('minimumApprovals', () => {
 
   it('returns fail when no-one approved but member was configured', async () => {
     const result = hasMinimumApprovals(
-      createHandlerContext({
-        config: createConfig({
-          minApprovals: {
-            MEMBER: 1
-          }
-        })
+      createConfig({
+        minApprovals: {
+          MEMBER: 1
+        }
       }),
       createPullRequestInfo({
         reviews: {

--- a/test/conditions/open.test.ts
+++ b/test/conditions/open.test.ts
@@ -1,10 +1,10 @@
 import open from '../../src/conditions/open'
-import { createHandlerContext, createPullRequestInfo } from '../mock'
+import { createPullRequestInfo, createConfig } from '../mock'
 
 describe('open', () => {
   it('returns success pull request state is open', async () => {
     const result = open(
-      createHandlerContext(),
+      createConfig(),
       createPullRequestInfo({
         state: 'OPEN'
       })
@@ -17,7 +17,7 @@ describe('open', () => {
     'MERGED'
   ])('returns fail pull request state is not %s', async (state) => {
     const result = open(
-      createHandlerContext(),
+      createConfig(),
       createPullRequestInfo({
         state
       })

--- a/test/conditions/requiredLabels.test.ts
+++ b/test/conditions/requiredLabels.test.ts
@@ -1,12 +1,10 @@
 import requiredLabels from '../../src/conditions/requiredLabels'
-import { createHandlerContext, createPullRequestInfo, createConfig } from '../mock'
+import { createPullRequestInfo, createConfig } from '../mock'
 
 describe('open', () => {
   it('returns success with no labels and no configuration', async () => {
     const result = requiredLabels(
-      createHandlerContext({
-        config: createConfig()
-      }),
+      createConfig(),
       createPullRequestInfo({
         labels: {
           nodes: []
@@ -18,10 +16,8 @@ describe('open', () => {
 
   it('returns fail with label not in configuration', async () => {
     const result = requiredLabels(
-      createHandlerContext({
-        config: createConfig({
-          requiredLabels: ['required label']
-        })
+      createConfig({
+        requiredLabels: ['required label']
       }),
       createPullRequestInfo({
         labels: {
@@ -36,10 +32,8 @@ describe('open', () => {
 
   it('returns success with label in configuration', async () => {
     const result = requiredLabels(
-      createHandlerContext({
-        config: createConfig({
-          requiredLabels: ['required label']
-        })
+      createConfig({
+        requiredLabels: ['required label']
       }),
       createPullRequestInfo({
         labels: {
@@ -54,10 +48,8 @@ describe('open', () => {
 
   it('returns success with multiple labels in pull request has required label in configuration', async () => {
     const result = requiredLabels(
-      createHandlerContext({
-        config: createConfig({
-          requiredLabels: ['required label']
-        })
+      createConfig({
+        requiredLabels: ['required label']
       }),
       createPullRequestInfo({
         labels: {
@@ -74,10 +66,8 @@ describe('open', () => {
 
   it('returns success with labels in pull request also in configuration', async () => {
     const result = requiredLabels(
-      createHandlerContext({
-        config: createConfig({
-          requiredLabels: ['required label', 'required label 2']
-        })
+      createConfig({
+        requiredLabels: ['required label', 'required label 2']
       }),
       createPullRequestInfo({
         labels: {
@@ -94,10 +84,8 @@ describe('open', () => {
 
   it('returns fail with labels in pull request also in configuration', async () => {
     const result = requiredLabels(
-      createHandlerContext({
-        config: createConfig({
-          requiredLabels: ['required label', 'required label 2']
-        })
+      createConfig({
+        requiredLabels: ['required label', 'required label 2']
       }),
       createPullRequestInfo({
         labels: {

--- a/test/conditions/upToDateBranch.test.ts
+++ b/test/conditions/upToDateBranch.test.ts
@@ -1,10 +1,10 @@
-import { defaultPullRequestInfo, createHandlerContext, createPullRequestInfo } from './../mock'
+import { defaultPullRequestInfo, createPullRequestInfo, createConfig } from './../mock'
 import upToDateBranch from '../../src/conditions/upToDateBranch'
 
 describe('upToDateBranch', () => {
   it('returns fail when pull request is based on strict protected branch and base of PR is not equals to baseRef', async () => {
     const status = upToDateBranch(
-      createHandlerContext(),
+      createConfig(),
       createPullRequestInfo({
         baseRef: {
           ...defaultPullRequestInfo.baseRef,
@@ -30,7 +30,7 @@ describe('upToDateBranch', () => {
 
   it('returns success when pull request is not based on strict protected branch but does have base of PR not equal to baseRef', async () => {
     const status = upToDateBranch(
-      createHandlerContext(),
+      createConfig(),
       createPullRequestInfo({
         baseRef: {
           ...defaultPullRequestInfo.baseRef,
@@ -56,7 +56,7 @@ describe('upToDateBranch', () => {
 
   it('returns success when pull request is based on strict protected branch and does have base of PR equal to baseRef', async () => {
     const status = upToDateBranch(
-      createHandlerContext(),
+      createConfig(),
       createPullRequestInfo({
         baseRef: {
           ...defaultPullRequestInfo.baseRef,

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -1,3 +1,4 @@
+import { ConditionConfig, defaultRuleConfig } from './../src/config'
 import { Review, CheckRun, PullRequestReviewState } from './../src/github-models'
 import { DeepPartial } from './../src/utils'
 import { HandlerContext } from './../src/models'
@@ -68,13 +69,23 @@ export function createGithubApi (options?: DeepPartial<GitHubAPI>): GitHubAPI {
   } as GitHubAPI
 }
 
-export function createConfig (options?: Partial<Config>): Config {
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+export type PartialConfig = {
+  rules?: Partial<ConditionConfig>[]
+} & Partial<Omit<Config, 'rules'>>
+
+export function createConfig (options?: PartialConfig): Config {
+  const rules = ((options || {}).rules || []).map(rule => ({
+    ...defaultRuleConfig,
+    ...rule
+  }))
   return {
     ...defaultConfig,
     minApprovals: {
       MEMBER: 1
     },
-    ...options
+    ...options,
+    rules
   }
 }
 

--- a/test/pull-request-status.test.ts
+++ b/test/pull-request-status.test.ts
@@ -1,7 +1,7 @@
 import { ConditionResults, Conditions, conditions } from './../src/conditions/index'
 import { getPullRequestStatus } from '../src/pull-request-status'
 import { mapObject } from '../src/utils'
-import { createHandlerContext, createPullRequestInfo } from './mock'
+import { createHandlerContext, createPullRequestInfo, createConfig, approvedReview } from './mock'
 import { ConditionResult } from '../src/condition'
 
 const successConditionResults: ConditionResults = mapObject(conditions, (_) => ({ status: 'success' } as ConditionResult))
@@ -10,6 +10,12 @@ function createConditionsFromResults (conditionResults: ConditionResults) {
   return mapObject(conditionResults, conditionResult => jest.fn(() => conditionResult))
 }
 
+function createConditions (overrideConditions: Partial<Conditions>): Conditions {
+  return {
+    ...createConditionsFromResults(successConditionResults),
+    ...overrideConditions
+  }
+}
 
 describe('pull request status', () => {
   it('calls all conditions', () => {
@@ -23,5 +29,103 @@ describe('pull request status', () => {
       expect(conditionFn).toHaveBeenCalledTimes(1)
     }
   })
+
+  it('returns success when all conditions and no configuration is defined', () => {
+    const successConditions = createConditionsFromResults(successConditionResults)
+    const results = getPullRequestStatus(
+      createHandlerContext(),
+      successConditions,
+      createPullRequestInfo()
+    )
+    expect(results).toEqual(successConditionResults)
+  })
+
+  it('returns fail when global config fails and a rule passes', () => {
+    const results = getPullRequestStatus(
+      createHandlerContext({
+        config: createConfig({
+          rules: [{
+            minApprovals: {
+              NONE: 0
+            }
+          }],
+          minApprovals: {
+            OWNER: 1
+          }
+        })
+      }),
+      createConditions({
+        minimumApprovals: conditions.minimumApprovals
+      }),
+      createPullRequestInfo({
+        reviews: {
+          nodes: [
+            approvedReview({
+              authorAssociation: 'MEMBER'
+            })
+          ]
+        }
+      })
+    )
+
+    expect(results.minimumApprovals.status).toEqual('fail')
+  })
+
+  it('returns success when global config passes and there are no rules', () => {
+    const results = getPullRequestStatus(
+      createHandlerContext({
+        config: createConfig({
+          rules: [],
+          minApprovals: {
+            MEMBER: 1
+          }
+        })
+      }),
+      createConditions({
+        minimumApprovals: conditions.minimumApprovals
+      }),
+      createPullRequestInfo({
+        reviews: {
+          nodes: [
+            approvedReview({
+              authorAssociation: 'MEMBER'
+            })
+          ]
+        }
+      })
+    )
+    expect(results.minimumApprovals.status).toEqual('success')
+  })
+
+  it('returns success when no global config and one rule and there are no rules', () => {
+    const results = getPullRequestStatus(
+      createHandlerContext({
+        config: createConfig({
+          rules: [{
+            minApprovals: {
+              OWNER: 1
+            }
+          }, {
+            minApprovals: {
+              MEMBER: 1
+            }
+          }]
+        })
+      }),
+      createConditions({
+        minimumApprovals: conditions.minimumApprovals
+      }),
+      createPullRequestInfo({
+        reviews: {
+          nodes: [
+            approvedReview({
+              authorAssociation: 'MEMBER'
+            })
+          ]
+        }
+      })
+    )
+
+    expect(results.minimumApprovals.status).toEqual('success')
   })
 })

--- a/test/pull-request-status.test.ts
+++ b/test/pull-request-status.test.ts
@@ -1,22 +1,27 @@
+import { ConditionResults, Conditions, conditions } from './../src/conditions/index'
 import { getPullRequestStatus } from '../src/pull-request-status'
-import { conditions } from '../src/conditions/'
 import { mapObject } from '../src/utils'
 import { createHandlerContext, createPullRequestInfo } from './mock'
+import { ConditionResult } from '../src/condition'
+
+const successConditionResults: ConditionResults = mapObject(conditions, (_) => ({ status: 'success' } as ConditionResult))
+
+function createConditionsFromResults (conditionResults: ConditionResults) {
+  return mapObject(conditionResults, conditionResult => jest.fn(() => conditionResult))
+}
+
 
 describe('pull request status', () => {
   it('calls all conditions', () => {
-    const conditionResults = mapObject(conditions, _ => ({ status: 'success' }))
-    for (let conditionName in conditions) {
-      (conditions as any)[conditionName] = jest.fn(() => (conditionResults as any)[conditionName])
-    }
-
-    const results = getPullRequestStatus(
+    const successConditions = createConditionsFromResults(successConditionResults)
+    getPullRequestStatus(
       createHandlerContext(),
+      successConditions,
       createPullRequestInfo()
     )
-    for (let conditionFn of Object.values(conditions)) {
+    for (let conditionFn of Object.values(successConditions)) {
       expect(conditionFn).toHaveBeenCalledTimes(1)
     }
-    expect(results).toEqual(conditionResults)
+  })
   })
 })


### PR DESCRIPTION
This PR adds the ability to configure multiple rules. Each rule has conditions, like the normal configuration. If any of the rules are passing its conditions, the PR will be auto-merged.

Note that global configuration will still override the rules if that fails one of its configured conditions. 

Solves #17 