### PR TITLE
add test for no configuration

### DIFF
--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -84,3 +84,45 @@ it('full happy path', async () => {
 
   expect(github.pullRequests.merge).toHaveBeenCalled()
 })
+
+it('no configuration should not schedule any pull request', async () => {
+  const app = new Application()
+
+  jest.mock('../src/pull-request-handler', () => {
+    return {
+      schedulePullRequestTrigger: jest.fn()
+    }
+  })
+
+  const github: any = {
+    repos: {
+      getContent: () => Promise.reject({ code: 404 })
+    }
+  } as DeepPartial<GitHubAPI>
+
+  app.auth = () => {
+    return Promise.resolve(github) as any
+  }
+
+  app.load(probotAutoMerge)
+
+  await app.receive({
+    event: 'pull_request',
+    payload: {
+      action: 'opened',
+      repository: {
+        owner: {
+          login: 'bobvanderlinden'
+        },
+        name: 'probot-auto-merge'
+      },
+      pull_request: {
+        number: 1
+      }
+    }
+  } as any)
+
+  const module: any = require('../src/pull-request-handler')
+
+  expect(module.schedulePullRequestTrigger).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
There was no test yet to check whether no configuration would indeed not result in a schedule of the PR.

This PR adds such a test.