### PR TITLE
Use fixed version of NodeJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^3.0.1"
   },
   "engines": {
-    "node": ">= 8.3.0"
+    "node": "8.3.x"
   },
   "standard": {
     "env": [


### PR DESCRIPTION
Currently the node engine `>= 8.3.0` is used. This is error-prone, as the version can increase in major steps.

This PR will solve that by using NodeJS version `8.3.x`.