### PR TITLE
Fix build of TypeScript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload
 
 script:
+- npm run build
 - npm run test:travis
 env:
   global:

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,5 +1,5 @@
+import { PullRequestQueryResult } from './../src/github-models'
 import { DeepPartial } from './../src/utils'
-import { PullRequestQueryResult } from './../lib/src/github-models.d'
 import { GitHubAPI } from 'probot/lib/github'
 import { Application } from 'probot'
 import probotAutoMerge from '../src/index'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,8 @@
     "src/**/*",
     "test/**/*"
   ],
+  "exclude": [
+    "lib/**/*"
+  ],
   "compileOnSave": false
 }


### PR DESCRIPTION
There was a reference to a file in `lib/` by accident. This resulted in a failing build.

This PR fixes the build and avoids the problem in the future.