### PR TITLE
Fix build problems due to inclusion of test directory

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,7 @@
     "declaration": true
   },
   "include": [
-    "src/**/*",
-    "test/**/*"
+    "src/**/*"
   ],
   "exclude": [
     "lib/**/*"


### PR DESCRIPTION
The test directory was added to tsconfig.json include section so that it would
be checked for build errors. However, this also resulted in `lib/index.js` being
moved to `lib/src/index.js`, which resulted in problems on Heroku.

This PR will resolve those problems by removing the test directory from tsconfig
again.