### PR TITLE
Allow waiting for pending PRs

### DIFF
--- a/src/delay.ts
+++ b/src/delay.ts
@@ -1,0 +1,22 @@
+export type CancelablePromise<T> = Promise<T> & { cancel?: () => void }
+
+export function delay (ms: number): CancelablePromise<void> {
+  let onCancel = null
+  const result: any = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      resolve()
+    }, ms)
+    onCancel = () => {
+      clearTimeout(timer)
+      resolve()
+    }
+  })
+  result.cancel = onCancel
+  return result
+}
+
+export function immediate (): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve)
+  })
+}

--- a/src/github-models.ts
+++ b/src/github-models.ts
@@ -4,9 +4,12 @@ export type MergeableState = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
 export type CommentAuthorAssociation = 'MEMBER' | 'OWNER' | 'COLLABORATOR' | 'CONTRIBUTOR' | 'FIRST_TIME_CONTRIBUTOR' | 'FIRST_TIMER' | 'NONE'
 export type PullRequestReviewState = 'PENDING' | 'COMMENTED' | 'APPROVED' | 'CHANGES_REQUESTED' | 'DISMISSED'
 
-export interface PullRequestReference {
+export interface RepositoryReference {
   owner: string
   repo: string
+}
+
+export interface PullRequestReference extends RepositoryReference {
   number: number
 }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,7 +2,7 @@ import { Context } from 'probot'
 import { Config } from './config'
 
 export interface HandlerContext {
-  log: (msg: string) => void
+  log: Context['log'],
   github: Context['github']
   config: Config
 }

--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -73,12 +73,7 @@ async function handlePullRequestTrigger (
   context: HandlerContext,
   pullRequestReference: PullRequestReference
 ) {
-  const { log: appLog } = context
   const pullRequestKey = getPullRequestKey(pullRequestReference)
-
-  function log (msg: string) {
-    appLog(`${pullRequestKey}: ${msg}`)
-  }
 
   // Cancel any running scheduled timer for this pull request,
   // since we're now handling it right now.
@@ -86,7 +81,11 @@ async function handlePullRequestTrigger (
 
   const pullRequestContext = {
     ...context,
-    log
+    log: context.log.child({
+      options: {
+        pullRequest: pullRequestReference.number
+      }
+    })
   }
   await doPullRequestWork(pullRequestContext, pullRequestReference)
 }

--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -118,6 +118,12 @@ async function doPullRequestWork (
 }
 
 export type PullRequestAction = 'reschedule' | 'update_branch' | 'merge' | 'delete_branch'
+export type PullRequestActions
+  = []
+  | ['reschedule']
+  | ['update_branch']
+  | ['merge']
+  | ['merge', 'delete_branch']
 
 /**
  * Determines which actions to take based on the pull request and the condition results
@@ -126,7 +132,7 @@ export function getPullRequestActions (
   context: HandlerContext,
   pullRequestInfo: PullRequestInfo,
   pullRequestStatus: PullRequestStatus
-): PullRequestAction[] {
+): PullRequestActions {
   const { config } = context
   const pending = Object.values(pullRequestStatus)
     .some(conditionResult => conditionResult.status === 'pending')
@@ -154,14 +160,9 @@ export function getPullRequestActions (
     return []
   }
 
-  return [
-    'merge',
-    ...(
-      config.deleteBranchAfterMerge && !isInFork(pullRequestInfo)
-      ? ['delete_branch'] as PullRequestAction[]
-      : []
-    )
-  ]
+  return config.deleteBranchAfterMerge && !isInFork(pullRequestInfo)
+    ? ['merge', 'delete_branch']
+    : ['merge']
 }
 
 function isInFork (pullRequestInfo: PullRequestInfo): boolean {

--- a/test/delay.test.ts
+++ b/test/delay.test.ts
@@ -1,0 +1,12 @@
+jest.useFakeTimers()
+
+it('delay', async () => {
+  const { delay, immediate } = require('../src/delay')
+  const callback = jest.fn()
+  delay(1000).then(callback)
+  expect(setTimeout).toBeCalled()
+  expect(callback).not.toBeCalled()
+  jest.runAllTimers()
+  await immediate()
+  expect(callback).toBeCalled()
+})

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -1,12 +1,13 @@
+import { PullRequestContext } from './../src/pull-request-handler'
 import { ConditionConfig, defaultRuleConfig } from './../src/config'
 import { Review, CheckRun, PullRequestReviewState } from './../src/github-models'
 import { DeepPartial } from './../src/utils'
-import { HandlerContext } from './../src/models'
-import {
-  PullRequestInfo
-} from '../src/models'
+import { HandlerContext, PullRequestReference, PullRequestQueryResult } from './../src/models'
+import { PullRequestInfo } from '../src/models'
 import { Config, defaultConfig } from '../src/config'
+import { Application, ApplicationFunction } from 'probot'
 import { GitHubAPI } from 'probot/lib/github'
+import { LoggerWithTarget } from 'probot/lib/wrap-logger'
 
 export const defaultPullRequestInfo: PullRequestInfo = {
   number: 1,
@@ -95,9 +96,17 @@ export function createConditionConfig (options?: PartialConfig): ConditionConfig
 
 export function createHandlerContext (options?: Partial<HandlerContext>): HandlerContext {
   return {
-    log: () => undefined,
+    log: createEmptyLogger(),
     github: options && options.github || createGithubApi(),
     config: options && options.config || createConfig(),
+    ...options
+  }
+}
+
+export function createPullRequestContext (options?: Partial<PullRequestContext>): PullRequestContext {
+  return {
+    ...createHandlerContext(options),
+    reschedulePullRequest: () => undefined,
     ...options
   }
 }
@@ -151,4 +160,114 @@ export const neutralCheckRun: CheckRun = {
   conclusion: 'neutral',
   head_sha: '12345',
   external_id: '1'
+}
+
+type BaseLogger = (...params: any[]) => void
+export function createLogger (baseLogger: BaseLogger): LoggerWithTarget {
+  const logger: LoggerWithTarget = ((...params) => baseLogger(...params)) as any
+  logger.info = logger
+  logger.debug = logger
+  logger.error = logger
+  logger.warn = logger
+  logger.trace = logger
+  logger.fatal = logger
+  logger.target = logger
+  logger.child = (opts) => logger
+  return logger
+}
+
+export function createEmptyLogger (): LoggerWithTarget {
+  return createLogger(() => undefined)
+}
+
+export function createApplication (opts: {
+  logger: LoggerWithTarget,
+  appFn: ApplicationFunction,
+  github: GitHubAPI
+}): Application {
+  const app = new Application()
+  app.catchErrors = false
+  app.log = opts.logger
+  app.auth = () => {
+    return Promise.resolve(opts.github)
+  }
+  app.load(opts.appFn)
+  return app
+}
+
+export function createPullRequestOpenedEvent (pullRequest: PullRequestReference): any {
+  return {
+    name: 'pull_request',
+    payload: {
+      installation: 1,
+      action: 'opened',
+      repository: {
+        owner: {
+          login: pullRequest.owner
+        },
+        name: pullRequest.repo
+      },
+      pull_request: {
+        number: pullRequest.number
+      }
+    }
+  }
+}
+
+export function createOkResponse (): any {
+  return jest.fn(() => ({ status: 200 }))
+}
+
+export function createGithubApiFromPullRequestInfo (opts: {
+  pullRequestInfo: PullRequestInfo,
+  config: string
+}): GitHubAPI {
+  const pullRequestQueryResult: PullRequestQueryResult = {
+    repository: {
+      pullRequest: opts.pullRequestInfo
+    }
+  }
+  return {
+    query: jest.fn(() => {
+      return pullRequestQueryResult
+    }),
+    checks: {
+      listForRef: jest.fn(() => ({
+        status: 200,
+        data: {
+          checkRuns: opts.pullRequestInfo.checkRuns
+        }
+      }))
+    },
+    pullRequests: {
+      merge: createOkResponse()
+    },
+    repos: {
+      merge: createOkResponse(),
+      getContent: createGetContent({
+        '.github/auto-merge.yml': () => Buffer.from(opts.config)
+      })
+    },
+    gitdata: {
+      deleteReference: createOkResponse()
+    }
+  } as any
+}
+
+export function createGetContent (paths: { [key: string]: () => Buffer }): any {
+  return ({ user, repo, path }: { user: string, repo: string, path: string }) => {
+    const contentFactory = paths[path]
+    if (!contentFactory) {
+      const error: any = new Error(`No content found at path: ${path}`)
+      error.code = 404
+      return Promise.reject(error)
+    }
+    const content = contentFactory().toString('base64')
+    return Promise.resolve({
+      status: 200,
+      data: {
+        content
+      }
+    })
+  }
 }

--- a/test/pull-request-handler.test.ts
+++ b/test/pull-request-handler.test.ts
@@ -4,7 +4,7 @@ import { conditions, ConditionName } from './../src/conditions/'
 import { ConditionResult } from './../src/condition'
 import { PullRequestInfo } from './../src/models'
 import { getPullRequestActions, executeAction } from '../src/pull-request-handler'
-import { createHandlerContext, createPullRequestInfo, createConfig, defaultPullRequestInfo, createGithubApi } from './mock'
+import { createHandlerContext, createPullRequestInfo, createConfig, defaultPullRequestInfo, createGithubApi, createPullRequestContext } from './mock'
 import { mapObject } from '../src/utils'
 
 const defaultBaseRef: PullRequestInfo['baseRef'] = {
@@ -183,7 +183,7 @@ describe('executeAction with action', () => {
   it('merge', async () => {
     const merge = jest.fn(() => ({ status: 200 }))
     await executeAction(
-      createHandlerContext({
+      createPullRequestContext({
         github: createGithubApi({
           pullRequests: {
             merge
@@ -220,7 +220,7 @@ describe('executeAction with action', () => {
   it('delete_branch', async () => {
     const deleteReference = jest.fn(() => ({ status: 200 }))
     await executeAction(
-      createHandlerContext({
+      createPullRequestContext({
         github: createGithubApi({
           gitdata: {
             deleteReference
@@ -255,7 +255,7 @@ describe('executeAction with action', () => {
   it('update_branch', async () => {
     const merge = jest.fn(() => ({ status: 200 }))
     await executeAction(
-      createHandlerContext({
+      createPullRequestContext({
         github: createGithubApi({
           repos: {
             merge
@@ -303,12 +303,14 @@ describe('executeAction with action', () => {
   })
 
   it('reschedule', async () => {
-    jest.useFakeTimers()
+    const reschedulePullRequest = jest.fn(() => undefined)
     await executeAction(
-      createHandlerContext(),
+      createPullRequestContext({
+        reschedulePullRequest
+      }),
       createPullRequestInfo(),
       'reschedule'
     )
-    expect(setTimeout).toHaveBeenCalledTimes(1)
+    expect(reschedulePullRequest).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Currently whenever a PR is still pending (due to running tests) it is rescheduled to the back of the queue.

This is inefficient when merging multiple PRs in one go: merging a PR will outdate other PRs. Are then all updated,
causing a merge commit from master to the PR in each of the leftover PRs. Once a PR has finished its tests, it will
be merged, outdating the other PRs again.

This causes a lot of unnecessary builds as well as merge commits.

This PR will reschedule pending PRs to the front of the queue, by also making 'waiting' a task that can be placed in front of the repository queue.