### PR TITLE
Apply default config to each configured rule

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,10 @@ export async function loadConfig (context: Context): Promise<Config | null> {
   const config = await getConfig(context, 'auto-merge.yml', defaultConfig)
   return config && {
     ...defaultConfig,
-    ...config
+    ...config,
+    rules: (config.rules || []).map((rule: any) => ({
+      ...defaultRuleConfig,
+      ...rule
+    }))
   }
 }


### PR DESCRIPTION
Currently whenever a rule was configured in auto-merge.yml, the user needed to explicitly set all condition configuration values.

This PR will apply defaults that also apply to the global configuration regarding condition configuration.