### PR TITLE
Add configuration file validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,11 @@
         }
       }
     },
+    "@mojotech/json-type-validation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mojotech/json-type-validation/-/json-type-validation-2.0.0.tgz",
+      "integrity": "sha512-smqRejcRnzku4rKjKfDMZXuVMB9tWpA19MpdALocJIDiTQffZHIy6sf5VC3l9MJsHggeGLkI548CDgwcIq2cww=="
+    },
     "@octokit/rest": {
       "version": "15.10.0",
       "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "heroku-postbuild": "npm run build"
   },
   "dependencies": {
+    "@mojotech/json-type-validation": "^2.0.0",
     "debug": "^3.1.0",
     "probot": "^7.1.0",
     "probot-config": "^0.2.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,26 @@
 import { CommentAuthorAssociation } from './github-models'
 import { Context } from 'probot'
 import getConfig from 'probot-config'
+import { Decoder, object, string, optional, number, boolean, array, oneOf, constant } from '@mojotech/json-type-validation'
+
+class ConfigNotFoundError extends Error {
+  constructor (
+    public readonly filePath: string
+  ) {
+    super(`Configuration file '${filePath}' not found`)
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}
+
+class ConfigValidationError extends Error {
+  constructor (
+    public readonly at: string,
+    public readonly message: string
+  ) {
+    super(`Configuration invalid: ${message} at ${at}`)
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}
 
 export type ConditionConfig = {
   minApprovals: { [key in CommentAuthorAssociation]?: number },
@@ -10,7 +30,7 @@ export type ConditionConfig = {
 }
 
 export type Config = {
-  rules?: ConditionConfig[],
+  rules: ConditionConfig[],
   updateBranch: boolean,
   deleteBranchAfterMerge: boolean,
   mergeMethod: 'merge' | 'rebase' | 'squash'
@@ -34,14 +54,62 @@ export const defaultConfig: Config = {
   ...defaultRuleConfig
 }
 
-export async function loadConfig (context: Context): Promise<Config | null> {
-  const config = await getConfig(context, 'auto-merge.yml', defaultConfig)
-  return config && {
+const reviewConfigDecover: Decoder<{ [key in CommentAuthorAssociation]: number | undefined }> = object({
+  MEMBER: optional(number()),
+  OWNER: optional(number()),
+  COLLABORATOR: optional(number()),
+  CONTRIBUTOR: optional(number()),
+  FIRST_TIME_CONTRIBUTOR: optional(number()),
+  FIRST_TIMER: optional(number()),
+  NONE: optional(number())
+})
+
+const conditionConfigDecoder: Decoder<ConditionConfig> = object({
+  minApprovals: reviewConfigDecover,
+  maxRequestedChanges: reviewConfigDecover,
+  requiredLabels: array(string()),
+  blockingLabels: array(string())
+})
+
+const configDecoder: Decoder<Config> = object({
+  rules: array(conditionConfigDecoder),
+  minApprovals: reviewConfigDecover,
+  maxRequestedChanges: reviewConfigDecover,
+  requiredLabels: array(string()),
+  blockingLabels: array(string()),
+  updateBranch: boolean(),
+  deleteBranchAfterMerge: boolean(),
+  mergeMethod: oneOf(
+    constant<'merge'>('merge'),
+    constant<'rebase'>('rebase'),
+    constant<'squash'>('squash')
+  )
+})
+
+export function validateConfig (config: any) {
+  return configDecoder.run(config)
+}
+
+export function getConfigFromUserConfig (userConfig: any): Config {
+  const config = {
     ...defaultConfig,
-    ...config,
-    rules: (config.rules || []).map((rule: any) => ({
+    ...userConfig,
+    rules: (userConfig.rules || []).map((rule: any) => ({
       ...defaultRuleConfig,
       ...rule
     }))
   }
+  const decoded = configDecoder.run(config)
+  if (!decoded.ok) {
+    throw new ConfigValidationError(decoded.error.message, decoded.error.at)
+  }
+  return decoded.result
+}
+
+export async function loadConfig (context: Context): Promise<Config> {
+  const userConfig = await getConfig(context, 'auto-merge.yml', defaultConfig)
+  if (!userConfig) {
+    throw new ConfigNotFoundError('.github/auto-merge.yml')
+  }
+  return getConfigFromUserConfig(userConfig)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,9 @@ Raven.config('https://ba659400a1784cbfb67b10013f46edbc@sentry.io/1260728', {
   }
 }).install()
 
-async function getHandlerContext (options: {app: Application, context: Context}): Promise<HandlerContext | null> {
+async function getHandlerContext (options: {app: Application, context: Context}): Promise<HandlerContext> {
   const config = await loadConfig(options.context)
-  return config && {
+  return {
     config,
     github: options.context.github,
     log: options.app.log
@@ -37,10 +37,6 @@ async function useHandlerContext (options: {app: Application, context: Context},
     }
   }, async () => {
     const handlerContext = await getHandlerContext(options)
-    if (!handlerContext) {
-      Raven.captureMessage(`Failed to get handler context`)
-      return
-    }
     await fn(handlerContext)
   })
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,4 +1,4 @@
-import { getConfigFromUserConfig } from '../src/config'
+import { getConfigFromUserConfig, defaultConfig } from '../src/config'
 
 describe('Config', () => {
   it('will throw upon invalid type', () => {
@@ -7,5 +7,15 @@ describe('Config', () => {
         minApprovals: []
       })
     }).toThrow()
+  })
+  it('will have default values for rules', () => {
+    const config = getConfigFromUserConfig({
+      rules: [{
+        minApprovals: {
+          OWNER: 1
+        }
+      }]
+    })
+    expect(config.rules[0].maxRequestedChanges.NONE).toBe(defaultConfig.maxRequestedChanges.NONE)
   })
 })

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,11 @@
+import { getConfigFromUserConfig } from '../src/config'
+
+describe('Config', () => {
+  it('will throw upon invalid type', () => {
+    expect(() => {
+      getConfigFromUserConfig({
+        minApprovals: []
+      })
+    }).toThrow()
+  })
+})

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -72,15 +72,15 @@ it('no configuration should not schedule any pull request', async () => {
     github
   })
 
-  await app.receive(
-    createPullRequestOpenedEvent({
-      owner: 'bobvanderlinden',
-      repo: 'probot-auto-merge',
-      number: 1
-    })
-  )
-
-  expect(require('../src/pull-request-handler').schedulePullRequestTrigger).not.toBeCalled()
+  expect(
+    app.receive(
+      createPullRequestOpenedEvent({
+        owner: 'bobvanderlinden',
+        repo: 'probot-auto-merge',
+        number: 1
+      })
+    )
+  ).rejects.toHaveProperty('message', "Configuration file '.github/auto-merge.yml' not found")
 })
 
 it('pending test', async () => {


### PR DESCRIPTION
Currently whenever a configuration file is available, defaults will be applied
and the result is used as-is.

It would be nice if the configuration was validated before use, so that strange
error will not occur due to configuration typing differences.

This PR will do validation for the configuration file and will fail in one place
when the configuration file does not follow the structure defined in TypeScript.