### PR TITLE
Fix failing rule results not being passed through

### DIFF
--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -148,15 +148,6 @@ it('pending test', async () => {
 
 it('to merge when one rule and the global configuration passes', async () => {
   const config = `
-    minApprovals:
-      COLLABORATOR: 0
-    maxRequestedChanges:
-      NONE: 0
-    blockingLabels:
-    - blocked
-
-    # Will merge whenever the above conditions are met, but also
-    # the owner has approved or merge label was added.
     rules:
     - minApprovals:
         OWNER: 1

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -145,3 +145,61 @@ it('pending test', async () => {
   expect(github.pullRequests.merge).toHaveBeenCalled()
 
 })
+
+it('to merge when one rule and the global configuration passes', async () => {
+  const config = `
+    minApprovals:
+      COLLABORATOR: 0
+    maxRequestedChanges:
+      NONE: 0
+    blockingLabels:
+    - blocked
+
+    # Will merge whenever the above conditions are met, but also
+    # the owner has approved or merge label was added.
+    rules:
+    - minApprovals:
+        OWNER: 1
+    - requiredLabels:
+      - merge
+  `
+
+  const pullRequestInfo = createPullRequestInfo({
+    reviews: {
+      nodes: [
+        approvedReview({
+          authorAssociation: 'CONTRIBUTOR'
+        })
+      ]
+    },
+    checkRuns: [
+      successCheckRun
+    ],
+    labels: {
+      nodes: [
+        { name: 'merge' }
+      ]
+    }
+  })
+
+  const github = createGithubApiFromPullRequestInfo({
+    pullRequestInfo,
+    config
+  })
+
+  const app = createApplication({
+    appFn: require('../src/index'),
+    logger: createEmptyLogger(),
+    github
+  })
+
+  await app.receive(
+    createPullRequestOpenedEvent({
+      owner: 'bobvanderlinden',
+      repo: 'probot-auto-merge',
+      number: 1
+    })
+  )
+
+  expect(github.pullRequests.merge).toHaveBeenCalled()
+})

--- a/test/pull-request-status.test.ts
+++ b/test/pull-request-status.test.ts
@@ -128,4 +128,26 @@ describe('pull request status', () => {
 
     expect(results.minimumApprovals.status).toEqual('success')
   })
+
+  it('returns fail when when one rule fails even if global succeeds', () => {
+    const results = getPullRequestStatus(
+      createHandlerContext({
+        config: createConfig({
+          rules: [{
+            requiredLabels: ['merge']
+          }]
+        })
+      }),
+      createConditions({
+        requiredLabels: conditions.requiredLabels
+      }),
+      createPullRequestInfo({
+        reviews: {
+          nodes: []
+        }
+      })
+    )
+
+    expect(results.requiredLabels.status).toEqual('fail')
+  })
 })


### PR DESCRIPTION
Currently when rules were defined and all of the rules did not succeed, then
the global configuration result would be used as a 'fallback' result.

This behavior is incorrect, as at least one of the rules need to pass before
the global result can be considered successful for a merge.

This PR will change the behavior so that the result of the first failing rule
will be passed back when none of the rules are succeeding.