### PR TITLE
Always reschedule pull request after updating branch

### DIFF
--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -48,7 +48,7 @@ export type PullRequestAction = 'reschedule' | 'update_branch' | 'merge' | 'dele
 export type PullRequestActions
   = []
   | ['reschedule']
-  | ['update_branch']
+  | ['update_branch', 'reschedule']
   | ['merge']
   | ['merge', 'delete_branch']
 
@@ -79,7 +79,7 @@ export function getPullRequestActions (
   if (requiresBranchUpdate(pullRequestInfo) && config.updateBranch) {
     return isInFork(pullRequestInfo)
       ? []
-      : ['update_branch']
+      : ['update_branch', 'reschedule']
   }
 
   return config.deleteBranchAfterMerge && !isInFork(pullRequestInfo)


### PR DESCRIPTION
Currently whenever a pull request was updated, other queued pull requests were evaluated afterwards. This resulted in updates in other pull requests as well while we already know those pull requests will be outdated when they are reevaluated.

This PR will make sure to reschedule a PR after updating its branch. That makes sure it is put in front of the queue, so it will be re-evaluated before other PRs.