### PR TITLE
Expand config validation information

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,12 +12,15 @@ class ConfigNotFoundError extends Error {
   }
 }
 
-class ConfigValidationError extends Error {
+export class ConfigValidationError extends Error {
   constructor (
-    public readonly at: string,
-    public readonly message: string
+    public readonly decoderError: {
+      at: string,
+      message: string
+    },
+    public readonly config: any
   ) {
-    super(`Configuration invalid: ${message} at ${at}`)
+    super(`Configuration invalid: ${decoderError.message}: ${decoderError.at}`)
     Object.setPrototypeOf(this, new.target.prototype)
   }
 }
@@ -101,7 +104,7 @@ export function getConfigFromUserConfig (userConfig: any): Config {
   }
   const decoded = configDecoder.run(config)
   if (!decoded.ok) {
-    throw new ConfigValidationError(decoded.error.message, decoded.error.at)
+    throw new ConfigValidationError(decoded.error, config)
   }
   return decoded.result
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,4 +1,4 @@
-import { getConfigFromUserConfig, defaultConfig } from '../src/config'
+import { getConfigFromUserConfig, defaultConfig, ConfigValidationError } from '../src/config'
 
 describe('Config', () => {
   it('will throw upon invalid type', () => {
@@ -8,6 +8,7 @@ describe('Config', () => {
       })
     }).toThrow()
   })
+
   it('will have default values for rules', () => {
     const config = getConfigFromUserConfig({
       rules: [{
@@ -17,5 +18,22 @@ describe('Config', () => {
       }]
     })
     expect(config.rules[0].maxRequestedChanges.NONE).toBe(defaultConfig.maxRequestedChanges.NONE)
+  })
+
+  it('will have default values for rules', () => {
+    const userConfig = {
+      blockingLabels: ['labela', { labelb: 'labelc' }]
+    }
+    const validationError: ConfigValidationError = (() => {
+      try {
+        getConfigFromUserConfig(userConfig)
+      } catch (err) {
+        return err
+      }
+    })()
+    expect(validationError).not.toBeUndefined()
+    expect(validationError.config.blockingLabels[1]).toEqual(userConfig.blockingLabels[1])
+    expect(validationError.decoderError.message).toEqual('expected a string, got an object')
+    expect(validationError.decoderError.at).toEqual('input.blockingLabels[1]')
   })
 })


### PR DESCRIPTION
Currently config validation errors were not very insightful in the error logs. This PR will expand the validation errors with additional information, like the configuration itself.