### PR TITLE
Validate query result for PR headRef

### DIFF
--- a/src/pull-request-query.ts
+++ b/src/pull-request-query.ts
@@ -74,12 +74,13 @@ export async function queryPullRequest (github: Context['github'], { owner, repo
   if (!response) {
     throw new Error(`Could not query pull request ${owner}/${repo}#${pullRequestNumber}`)
   }
-  if (!response.repository) {
-    const error: any = new Error(`Query result does not have repository`)
+  if (!response.repository || !response.repository.pullRequest || !response.repository.pullRequest.headRef) {
+    const error: any = new Error(`Query result is not complete`)
     error.pullRequest = `${owner}/${repo}#${pullRequestNumber}`
     error.response = response
     throw error
   }
+
   const queryResult = response as PullRequestQueryResult
 
   const checks = result<{ check_runs: CheckRun[] }>(await github.checks.listForRef({


### PR DESCRIPTION
In response to https://github.com/bobvanderlinden/probot-auto-merge/issues/51

There are some cases where PRs do not seem to have a `headRef`. Handling the PR
without a `headRef` is near impossible. We need more information about these
query results.

In this PR we will validate the `headRef` of the query result and send additional
information in the error whenever it such a field is missing.