### PR TITLE
Add pullRequestInfo to reported errors

### DIFF
--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -1,5 +1,5 @@
-import { conditions } from './conditions/index'
 import Raven from 'raven'
+import { conditions } from './conditions/index'
 import { HandlerContext, PullRequestReference, PullRequestInfo } from './models'
 import { result } from './utils'
 import { getPullRequestStatus, PullRequestStatus } from './pull-request-status'
@@ -20,7 +20,12 @@ export async function handlePullRequest (
     context.github,
     pullRequestReference
   )
-  context.log.debug('pullRequestInfo:', pullRequestInfo)
+
+  Raven.mergeContext({
+    extra: {
+      pullRequestInfo
+    }
+  })
 
   const pullRequestStatus = getPullRequestStatus(
     context,


### PR DESCRIPTION
Currently it is often hard to figure out why handling a pull request has failed.
It would be nice to have the pullRequestInfo, so it can be more easily
reproduced and also a test be created for such a case.

This PR will add pullRequestInfo to reported errors.