### PR TITLE
Fix tests by exiting with 1 on unhandled promise rejections

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     ]
   },
   "jest": {
+    "setupFiles": [
+      "./test/jest-setup.ts"
+    ],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/src/pull-request-query.ts
+++ b/src/pull-request-query.ts
@@ -2,6 +2,14 @@ import { PullRequestReference, CheckRun, PullRequestInfo, PullRequestQueryResult
 import { Context } from 'probot'
 import { result } from './utils'
 
+function assertPullRequest(pullRequest: PullRequestReference, condition: boolean, errorMessage: string) {
+  if (!condition) {
+    const error: any = new Error(errorMessage)
+    error.pullRequest = `${pullRequest.owner}/${pullRequest.repo}#${pullRequest.number}`
+    throw error
+  }
+}
+
 export async function queryPullRequest (github: Context['github'], { owner, repo, number: pullRequestNumber }: PullRequestReference): Promise<PullRequestInfo> {
   const response = await github.query(`
     query PullRequestQuery($owner:String!, $repo:String!, $pullRequestNumber:Int!) {
@@ -71,14 +79,16 @@ export async function queryPullRequest (github: Context['github'], { owner, repo
     'repo': repo,
     'pullRequestNumber': pullRequestNumber
   }) as any
-  if (!response) {
-    throw new Error(`Could not query pull request ${owner}/${repo}#${pullRequestNumber}`)
-  }
-  if (!response.repository.pullRequest.headRef && !response.repository.mergeable) {
-    const error: any = new Error(`No permission to source repository of pull request`)
-    error.pullRequest = `${owner}/${repo}#${pullRequestNumber}`
-    throw error
-  }
+
+  const assert = assertPullRequest.bind(null, {
+    owner,
+    repo,
+    number: pullRequestNumber
+  })
+
+  assert(response, 'Could not query pull request')
+  assert(response.repository, 'Query result does not have repository')
+  assert(response.repository.pullRequest.headRef && response.repository.pullRequest.mergeable, 'No permission to source repository of pull request')
 
   const queryResult = response as PullRequestQueryResult
 

--- a/src/pull-request-query.ts
+++ b/src/pull-request-query.ts
@@ -2,7 +2,7 @@ import { PullRequestReference, CheckRun, PullRequestInfo, PullRequestQueryResult
 import { Context } from 'probot'
 import { result } from './utils'
 
-function assertPullRequest(pullRequest: PullRequestReference, condition: boolean, errorMessage: string) {
+function assertPullRequest (pullRequest: PullRequestReference, condition: boolean, errorMessage: string) {
   if (!condition) {
     const error: any = new Error(errorMessage)
     error.pullRequest = `${pullRequest.owner}/${pullRequest.repo}#${pullRequest.number}`

--- a/test/jest-setup.ts
+++ b/test/jest-setup.ts
@@ -1,0 +1,3 @@
+process.on('unhandledRejection', reason => {
+  throw reason
+})

--- a/test/pull-request-query.test.ts
+++ b/test/pull-request-query.test.ts
@@ -36,7 +36,7 @@ describe('queryPullRequest', () => {
         query
       }),
       { owner: 'bobvanderlinden', repo: 'probot-auto-merge', number: 1 }
-    )).rejects.toThrow('Could not query')
+    )).rejects.toThrowError('Could not query pull request')
   })
 
   it('should throw error when empty query response', async () => {
@@ -47,6 +47,6 @@ describe('queryPullRequest', () => {
         query
       }),
       { owner: 'bobvanderlinden', repo: 'probot-auto-merge', number: 1 }
-    )).rejects.toThrow('Query result does not have repository')
+    )).rejects.toThrowError('Query result does not have repository')
   })
 })

--- a/test/pull-request-query.test.ts
+++ b/test/pull-request-query.test.ts
@@ -49,4 +49,21 @@ describe('queryPullRequest', () => {
       { owner: 'bobvanderlinden', repo: 'probot-auto-merge', number: 1 }
     )).rejects.toThrowError('Query result does not have repository')
   })
+
+  it('should throw error when no headRef and not mergeable', async () => {
+    const query = jest.fn(() => createPullRequestInfo({
+      repository: {
+        pullRequest: {
+          headRef: undefined,
+          mergeable: undefined
+        }
+      }
+    } as any))
+    expect(queryPullRequest(
+      createGithubApi({
+        query
+      }),
+      { owner: 'bobvanderlinden', repo: 'probot-auto-merge', number: 1 }
+    )).rejects.toThrowError('No permission to source repository of pull request')
+  })
 })


### PR DESCRIPTION
Previously tests would pass whenever promise rejections were failing. These rejections only
resulted in a warning and should actually result in an error. This has resulted in a few tests
passing where they shouldn't be passing.