### PR TITLE
Handle check_run.completed events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,8 @@ export = (app: Application) => {
   app.on([
     'check_run.created',
     'check_run.rerequested',
-    'check_run.requested_action'
+    'check_run.requested_action',
+    'check_run.completed'
   ], async context => {
     await handlePullRequests(app, context, {
       owner: context.payload.repository.owner.login,


### PR DESCRIPTION
Previously `check_run.completed` events were ignored, which resulted in PRs not being evaluated asap.

This PR will fix that issue.