### PR TITLE
Use branchProtectionRules instead of protectedBranches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,12 @@
       "integrity": "sha512-D1xlXHZpDonVX+VJ28XtcD5xlu8ex6Fc4cQNnrm2wJvlQnbec9RedhCrhQr6kRAE9XWHSec+JPuTmqJ9jC0qsA==",
       "dev": true
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "10.11.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.3.tgz",
@@ -207,7 +213,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -841,7 +846,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
-      "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
@@ -859,7 +864,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -2020,7 +2025,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -2379,7 +2384,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -2627,7 +2632,7 @@
     },
     "express": {
       "version": "4.16.3",
-      "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
         "accepts": "~1.3.5",
@@ -2706,7 +2711,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -2807,7 +2812,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -2976,14 +2981,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2998,20 +3001,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3128,8 +3128,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3141,7 +3140,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3156,7 +3154,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3164,14 +3161,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3190,7 +3185,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3271,8 +3265,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3284,7 +3277,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3406,7 +3398,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3587,7 +3578,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -3780,7 +3771,7 @@
         },
         "handlebars": {
           "version": "4.0.5",
-          "resolved": "http://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
           "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
           "requires": {
             "async": "^1.4.0",
@@ -3863,7 +3854,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -3991,7 +3982,7 @@
     },
     "inquirer": {
       "version": "5.2.0",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
       "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "dev": true,
       "requires": {
@@ -4065,7 +4056,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -4205,7 +4196,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -4968,7 +4959,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -5189,8 +5180,7 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "optional": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -5385,7 +5375,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
@@ -5411,7 +5401,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -5546,7 +5536,7 @@
     },
     "ncp": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "optional": true
     },
@@ -5995,7 +5985,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -7356,7 +7346,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -7783,7 +7773,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -7950,7 +7940,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
@@ -8024,7 +8014,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -8668,7 +8658,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -8751,7 +8741,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -8864,7 +8854,7 @@
     },
     "yargs": {
       "version": "11.1.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@mojotech/json-type-validation": "^2.0.0",
     "bunyan-sentry-stream": "^1.2.1",
     "debug": "^4.0.1",
+    "minimatch": "^3.0.4",
     "probot": "^7.2.0",
     "probot-config": "^0.2.0",
     "raven": "^2.6.4"
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@types/debug": "0.0.31",
     "@types/jest": "^23.3.2",
+    "@types/minimatch": "^3.0.3",
     "@types/node": "^10.11.3",
     "@types/p-queue": "^2.3.1",
     "@types/raven": "^2.5.1",

--- a/src/github-models.ts
+++ b/src/github-models.ts
@@ -94,11 +94,11 @@ export interface PullRequestQueryResult {
       },
       headRefOid: string,
       repository: {
-        protectedBranches: {
+        branchProtectionRules: {
           nodes: Array<{
-            name: string,
-            hasRestrictedPushes: boolean,
-            hasStrictRequiredStatusChecks: boolean
+            pattern: string,
+            restrictsPushes: boolean,
+            requiresStrictStatusChecks: boolean
           }>
         }
       }

--- a/src/pull-request-query.ts
+++ b/src/pull-request-query.ts
@@ -64,11 +64,11 @@ export async function queryPullRequest (github: Context['github'], { owner, repo
           }
           headRefOid
           repository {
-            protectedBranches(last: 100) {
+            branchProtectionRules(last: 100) {
               nodes {
-                name
-                hasRestrictedPushes
-                hasStrictRequiredStatusChecks
+                pattern
+                restrictsPushes
+                requiresStrictStatusChecks
               }
             }
           }

--- a/src/pull-request-uptodate.ts
+++ b/src/pull-request-uptodate.ts
@@ -1,12 +1,11 @@
 import { PullRequestInfo } from './github-models'
+import minimatch from 'minimatch'
 
 export function requiresBranchUpdate (pullRequestInfo: PullRequestInfo) {
-  const protectedBranch = pullRequestInfo.repository.protectedBranches.nodes
-    .filter(protectedBranch => protectedBranch.name === pullRequestInfo.baseRef.name)[0]
-
-  return protectedBranch
-    && protectedBranch.hasStrictRequiredStatusChecks
-    && !isUpToDate(pullRequestInfo)
+  const matchingBranchProtectionRules = pullRequestInfo.repository.branchProtectionRules.nodes
+    .filter(rule => minimatch(pullRequestInfo.baseRef.name, rule.pattern))
+  const requiresStrictStatusChecks = matchingBranchProtectionRules.some(rule => rule.requiresStrictStatusChecks)
+  return requiresStrictStatusChecks && !isUpToDate(pullRequestInfo)
 }
 
 export function isUpToDate (pullRequestInfo: PullRequestInfo) {

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -50,7 +50,7 @@ export const defaultPullRequestInfo: PullRequestInfo = {
     nodes: []
   },
   repository: {
-    protectedBranches: {
+    branchProtectionRules: {
       nodes: []
     }
   },

--- a/test/pull-request-handler.test.ts
+++ b/test/pull-request-handler.test.ts
@@ -87,11 +87,11 @@ describe('getPullRequestPlan', () => {
         headRef: headRefInSameRepository,
         baseRefOid: '2',
         repository: {
-          protectedBranches: {
+          branchProtectionRules: {
             nodes: [{
-              name: 'master',
-              hasRestrictedPushes: true,
-              hasStrictRequiredStatusChecks: true
+              pattern: 'master',
+              restrictsPushes: true,
+              requiresStrictStatusChecks: true
             }]
           }
         }
@@ -119,11 +119,11 @@ describe('getPullRequestPlan', () => {
         },
         baseRefOid: '3',
         repository: {
-          protectedBranches: {
+          branchProtectionRules: {
             nodes: [{
-              name: 'master',
-              hasRestrictedPushes: true,
-              hasStrictRequiredStatusChecks: true
+              pattern: 'master',
+              restrictsPushes: true,
+              requiresStrictStatusChecks: true
             }]
           }
         }
@@ -156,11 +156,11 @@ describe('getPullRequestPlan', () => {
         },
         baseRefOid: '3',
         repository: {
-          protectedBranches: {
+          branchProtectionRules: {
             nodes: [{
-              name: 'master',
-              hasRestrictedPushes: true,
-              hasStrictRequiredStatusChecks: true
+              pattern: 'master',
+              restrictsPushes: true,
+              requiresStrictStatusChecks: true
             }]
           }
         }

--- a/test/pull-request-uptodate.test.ts
+++ b/test/pull-request-uptodate.test.ts
@@ -14,11 +14,11 @@ describe('requiresBranchUpdate', () => {
         },
         baseRefOid: '0000000000000000000000000000000000000000',
         repository: {
-          protectedBranches: {
+          branchProtectionRules: {
             nodes: [{
-              name: 'master',
-              hasRestrictedPushes: true,
-              hasStrictRequiredStatusChecks: true
+              pattern: 'master',
+              restrictsPushes: true,
+              requiresStrictStatusChecks: true
             }]
           }
         }
@@ -39,11 +39,11 @@ describe('requiresBranchUpdate', () => {
         },
         baseRefOid: '0000000000000000000000000000000000000000',
         repository: {
-          protectedBranches: {
+          branchProtectionRules: {
             nodes: [{
-              name: 'master',
-              hasRestrictedPushes: true,
-              hasStrictRequiredStatusChecks: false
+              pattern: 'master',
+              restrictsPushes: true,
+              requiresStrictStatusChecks: false
             }]
           }
         }
@@ -64,16 +64,41 @@ describe('requiresBranchUpdate', () => {
         },
         baseRefOid: '0000000000000000000000000000000000000000',
         repository: {
-          protectedBranches: {
+          branchProtectionRules: {
             nodes: [{
-              name: 'master',
-              hasRestrictedPushes: true,
-              hasStrictRequiredStatusChecks: true
+              pattern: 'master',
+              restrictsPushes: true,
+              requiresStrictStatusChecks: true
             }]
           }
         }
       })
     )
     expect(result).toBe(false)
+  })
+
+  it('returns true when pull request is based on strict protected branch using pattern and base of PR is not equals to baseRef', async () => {
+    const result = requiresBranchUpdate(
+      createPullRequestInfo({
+        baseRef: {
+          ...defaultPullRequestInfo.baseRef,
+          name: 'master',
+          target: {
+            oid: '1111111111111111111111111111111111111111'
+          }
+        },
+        baseRefOid: '0000000000000000000000000000000000000000',
+        repository: {
+          branchProtectionRules: {
+            nodes: [{
+              pattern: 'mas*',
+              restrictsPushes: true,
+              requiresStrictStatusChecks: true
+            }]
+          }
+        }
+      })
+    )
+    expect(result).toBe(true)
   })
 })


### PR DESCRIPTION
Github's GraphQL definition has deprecated `protectedBranches` and will be removed
in the future. The alternative is `branchProtectionRules`.

This PR will use `branchProtectionRules`. It now supports a fnmatch pattern for matching the branch name.
This PR uses minimatch to support pattern-matching.