### PR TITLE
add action failure reporting to status checks

### DIFF
--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -183,8 +183,22 @@ export async function executeActions (
   actions: PullRequestAction[]
 ) {
   for (let action of actions) {
-    await executeAction(context, pullRequestInfo, action)
+    try {
+      await executeAction(context, pullRequestInfo, action)
+    } catch (err) {
+      await updateStatusReportCheck(context, pullRequestInfo, `Failed to ${getPullRequestActionName(action)}`, err.toString())
+      throw err
+    }
   }
+}
+
+export function getPullRequestActionName (action: PullRequestAction) {
+  return ({
+    'delete_branch': 'delete branch',
+    'merge': 'merge',
+    'reschedule': 'reschedule',
+    'update_branch': 'update branch'
+  })[action]
 }
 
 export async function executeAction (


### PR DESCRIPTION
Currently whenever a merge, delete or update fails, the failure status is not reported to the check API status of the bot. This is confusing as it will show the bot is still 'merging' while it has already failed to do so.

In response to #51, this PR will report on action failures. It will show the action that failed and in the details show the full exception.
