### PR TITLE
Add missing submittedAt to the graphql query

### DIFF
--- a/src/pull-request-query.ts
+++ b/src/pull-request-query.ts
@@ -27,6 +27,7 @@ export async function queryPullRequest (github: Context['github'], { owner, repo
               author {
                 login
               }
+              submittedAt
               state
             }
           }


### PR DESCRIPTION
Currently the graphql query does not fetch `submittedAt`, but `submittedAt` is being used to sort all reviews of a PR. Because there was no `submittedAt`, the reviews were ordered incorrectly. In some cases when a user dismissed and approved a PR, it would not be automatically merged.

This PR will add the missing `submittedAt` to the graphql query.