### PR TITLE
Improve type information in mocks

### DIFF
--- a/test/mock.ts
+++ b/test/mock.ts
@@ -8,6 +8,7 @@ import { Config, defaultConfig } from '../src/config'
 import { Application, ApplicationFunction } from 'probot'
 import { GitHubAPI } from 'probot/lib/github'
 import { LoggerWithTarget } from 'probot/lib/wrap-logger'
+import { Response, GitdataDeleteReferenceResponse } from '@octokit/rest'
 
 export const defaultPullRequestInfo: PullRequestInfo = {
   number: 1,
@@ -294,7 +295,7 @@ export function createCheckSuiteCompletedEvent (pullRequest: PullRequestReferenc
   }
 }
 
-export function createOkResponse (): any {
+export function createOkResponse<T> (): (...args: any[]) => Response<T> {
   return jest.fn(() => ({ status: 200 }))
 }
 
@@ -302,6 +303,13 @@ export function createGithubApiFromPullRequestInfo (opts: {
   pullRequestInfo: PullRequestInfo,
   config: string
 }): GitHubAPI {
+  return createPartialGithubApiFromPullRequestInfo(opts) as GitHubAPI
+}
+
+function createPartialGithubApiFromPullRequestInfo (opts: {
+  pullRequestInfo: PullRequestInfo,
+  config: string
+}): DeepPartial<GitHubAPI> {
   const pullRequestQueryResult: PullRequestQueryResult = {
     repository: {
       pullRequest: opts.pullRequestInfo
@@ -331,9 +339,9 @@ export function createGithubApiFromPullRequestInfo (opts: {
       })
     },
     gitdata: {
-      deleteReference: createOkResponse()
+      deleteReference: createOkResponse<GitdataDeleteReferenceResponse>()
     }
-  } as any
+  }
 }
 
 export function createGetContent (paths: { [key: string]: () => Buffer }): any {

--- a/test/status-report.test.ts
+++ b/test/status-report.test.ts
@@ -1,4 +1,4 @@
-import { CheckRun } from './../lib/github-models.d'
+import { CheckRun } from './../src/github-models'
 import { createPullRequestInfo, createPullRequestContext, createGithubApi, createCheckRun, createConfig } from './mock'
 import { updateStatusReportCheck } from '../src/status-report'
 


### PR DESCRIPTION
Currently the mocks are often using explicit `any`. It would be nice to type these
instances correctly, so that changes in types can be detected earlier.