### PR TITLE
Upgrade probot to 7.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,9 +41,9 @@
       }
     },
     "@octokit/rest": {
-      "version": "15.13.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.13.1.tgz",
-      "integrity": "sha512-r6aRAZaaUZkTqtI4seaSamvgqmYswXpxclIqUrwtFtOuRAnE7l0aeWU252vQ/mxd1wKZWMq1oFChzk0/qzcYcg==",
+      "version": "15.18.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.18.0.tgz",
+      "integrity": "sha512-D1dDJMbvT4dok9++vc8uwCr92ndadwfz6vHK+IklzBHKSsuLlhpv2/dzx97Y4aRlm0t74LeXKDp4j0b4M2vmQw==",
       "requires": {
         "before-after-hook": "^1.1.0",
         "btoa-lite": "^1.0.0",
@@ -1062,9 +1062,9 @@
       }
     },
     "before-after-hook": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
-      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.2.0.tgz",
+      "integrity": "sha512-wI3QtdLppHNkmM1VgRVLCrlWCKk/YexlPicYbXPs4eYdd1InrUCTFsx5bX1iUQzzMsoRXXPpM1r+p7JEJJydag=="
     },
     "binary-extensions": {
       "version": "1.12.0",
@@ -1113,9 +1113,9 @@
       }
     },
     "bottleneck": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.12.1.tgz",
-      "integrity": "sha512-wPHlAip5O1Po5AoDIyMRb7K2LgxmkOviAS91wsOgaa3hg0D8tOHuctQdg1F5fWG9Csi1wYQlU6sTSAp2PhejCw=="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.13.0.tgz",
+      "integrity": "sha512-9YmZ0aiKta2OAxTujKCS/INjGWCIGWK4Ff1nQpgHnR4CTjlk9jcnpaHOjPnMZPtqRXkqwKdtxZgvJ9udsXylaw=="
     },
     "boxen": {
       "version": "1.3.0",
@@ -1853,6 +1853,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
     },
     "default-require-extensions": {
       "version": "1.0.0",
@@ -3523,8 +3528,7 @@
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
       "version": "2.0.6",
@@ -4062,9 +4066,9 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-base64": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-0.0.5.tgz",
-      "integrity": "sha512-eRLie1GvKWp5Hab3x0uZXOvxrlw72elV2qEcvrNeoqNv6W30BjyvdiEqouaIrU3qh5KWRlxJp7iDLipA/hNOsA=="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-0.1.0.tgz",
+      "integrity": "sha512-WRRyllsGXJM7ZN7gPTCCQ/6wNPTRDwiWdPK66l5sJzcU/oOzcIcRRf0Rux8bkpox/1yjt0F6VJRsQOIG2qz5sg=="
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -4315,8 +4319,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -4354,8 +4357,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "2.1.0",
@@ -4990,9 +4992,9 @@
       "dev": true
     },
     "jsonwebtoken": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
-      "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
+      "integrity": "sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==",
       "requires": {
         "jws": "^3.1.5",
         "lodash.includes": "^4.3.0",
@@ -5239,9 +5241,9 @@
       }
     },
     "macos-release": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
-      "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
+      "integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A=="
     },
     "make-dir": {
       "version": "1.3.0",
@@ -5579,13 +5581,12 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-fetch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
-      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -5674,7 +5675,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -5874,12 +5874,12 @@
       }
     },
     "os-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
-      "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
+      "integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
       "requires": {
-        "macos-release": "^1.0.0",
-        "win-release": "^1.0.0"
+        "macos-release": "^2.0.0",
+        "windows-release": "^3.1.0"
       }
     },
     "os-tmpdir": {
@@ -5891,8 +5891,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "1.3.0",
@@ -5990,8 +5989,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.5",
@@ -6180,11 +6178,11 @@
       "dev": true
     },
     "probot": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/probot/-/probot-7.3.1.tgz",
-      "integrity": "sha512-zzavBZAe1kSk3dJnhHOTmd+x1uxktuKe67KKKTNiqO+Cmov38Gsb1FCzMtjoxvatvGfVvpOg9tJb+13cQAdgCA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/probot/-/probot-7.4.0.tgz",
+      "integrity": "sha512-xyvra7baRi8o/KortENZHFae8TZCBHvrKKTVvL1l5DhLBb1mfey+6AM2bxEai5ajDkrKnNiA69aDtb32WO5bRQ==",
       "requires": {
-        "@octokit/rest": "^15.13.1",
+        "@octokit/rest": "^15.18.0",
         "@octokit/webhooks": "^5.0.2",
         "@types/supports-color": "^5.3.0",
         "bottleneck": "^2.8.0",
@@ -6197,7 +6195,7 @@
         "express": "^4.16.2",
         "express-async-errors": "^3.0.0",
         "hbs": "^4.0.1",
-        "is-base64": "0.0.5",
+        "is-base64": "0.1.0",
         "js-yaml": "^3.9.1",
         "jsonwebtoken": "^8.1.0",
         "pkg-conf": "^2.0.0",
@@ -6232,10 +6230,10 @@
       }
     },
     "probot-config": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/probot-config/-/probot-config-0.2.0.tgz",
-      "integrity": "sha512-xURFHWnzna2Gphw9LJgI9PTzDKZKxgGWGidfwXKlhP09F226UgxMsA2uMLlG7LEKNsKP1Yx9SAec8tsDYw2lNw==",
+      "version": "git+ssh://git@github.com/bobvanderlinden/probot-config.git#9825185ee0a1698120193ad34e6832bc43f90e18",
+      "from": "git+ssh://git@github.com/bobvanderlinden/probot-config.git#pr-probot-7.4.0",
       "requires": {
+        "deepmerge": "^2.2.1",
         "js-yaml": "^3.10.0"
       }
     },
@@ -7479,7 +7477,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -7487,8 +7484,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shellwords": {
       "version": "0.1.1",
@@ -7499,8 +7495,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sisteransi": {
       "version": "0.1.1",
@@ -7907,8 +7902,7 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -8452,11 +8446,11 @@
       }
     },
     "universal-user-agent": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.1.tgz",
-      "integrity": "sha512-vz+heWVydO0iyYAa65VHD7WZkYzhl7BeNVy4i54p4TF8OMiLSXdbuQe4hm+fmWAsL+rVibaQHXfhvkw3c1Ws2w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.2.tgz",
+      "integrity": "sha512-nOwvHWLH3dBazyuzbECPA5uVFNd7AlgviXRHgR4yf48QqitIvpdncRrxMbZNMpPPEfgz30I9ubd1XmiJiqsTrg==",
       "requires": {
-        "os-name": "^2.0.1"
+        "os-name": "^3.0.0"
       }
     },
     "unpipe": {
@@ -8523,9 +8517,9 @@
       "dev": true
     },
     "update-dotenv": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-dotenv/-/update-dotenv-1.1.0.tgz",
-      "integrity": "sha512-37KqjTZTJoXGQI6iI6PNo9lRsBHNtisBISyDCYLrR0hf2YlQo0Gw18v6DXseWk7kWJr33sHh5sMP78ofzbd/ag=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-dotenv/-/update-dotenv-1.1.1.tgz",
+      "integrity": "sha512-3cIC18In/t0X/yH793c00qqxcKD8jVCgNOPif/fGQkFpYMGecM9YAc+kaAKXuZsM2dE9I9wFI7KvAuNX22SGMQ=="
     },
     "update-notifier": {
       "version": "2.5.0",
@@ -8728,7 +8722,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -8748,19 +8741,47 @@
         "string-width": "^2.1.1"
       }
     },
-    "win-release": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
-      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
-      "requires": {
-        "semver": "^5.0.1"
-      }
-    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "optional": true
+    },
+    "windows-release": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
+      "integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
+      "requires": {
+        "execa": "^0.10.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
+      }
     },
     "wordwrap": {
       "version": "0.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6230,8 +6230,8 @@
       }
     },
     "probot-config": {
-      "version": "git+ssh://git@github.com/bobvanderlinden/probot-config.git#9825185ee0a1698120193ad34e6832bc43f90e18",
-      "from": "git+ssh://git@github.com/bobvanderlinden/probot-config.git#pr-probot-7.4.0",
+      "version": "git+https://github.com/bobvanderlinden/probot-config.git#9825185ee0a1698120193ad34e6832bc43f90e18",
+      "from": "git+https://github.com/bobvanderlinden/probot-config.git#pr-probot-7.4.0",
       "requires": {
         "deepmerge": "^2.2.1",
         "js-yaml": "^3.10.0"

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "bunyan-sentry-stream": "*",
     "debug": "*",
     "minimatch": "*",
-    "probot": "*",
-    "probot-config": "git+ssh://git@github.com:bobvanderlinden/probot-config#pr-probot-7.4.0",
+    "probot": "^7.4.0",
+    "probot-config": "git+https://github.com:bobvanderlinden/probot-config#pr-probot-7.4.0",
     "raven": "*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "debug": "*",
     "minimatch": "*",
     "probot": "*",
-    "probot-config": "*",
+    "probot-config": "git+ssh://git@github.com:bobvanderlinden/probot-config#pr-probot-7.4.0",
     "raven": "*"
   },
   "devDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,7 +117,7 @@ export function getConfigFromUserConfig (userConfig: any): Config {
 }
 
 export async function loadConfig (context: Context): Promise<Config> {
-  const userConfig = await getConfig(context, 'auto-merge.yml', defaultConfig)
+  const userConfig = await getConfig(context, 'auto-merge.yml', null)
   if (!userConfig) {
     throw new ConfigNotFoundError('.github/auto-merge.yml')
   }

--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -169,7 +169,7 @@ async function deleteBranch (
   pullRequestInfo: PullRequestInfo
 ) {
   return result(
-    await context.github.gitdata.deleteReference({
+    await context.github.gitdata.deleteRef({
       owner: pullRequestInfo.headRef.repository.owner.login,
       repo: pullRequestInfo.headRef.repository.name,
       ref: `heads/${pullRequestInfo.headRef.name}`

--- a/src/pull-request-query.ts
+++ b/src/pull-request-query.ts
@@ -81,7 +81,7 @@ export async function queryPullRequest (github: Context['github'], { owner, repo
     'owner': owner,
     'repo': repo,
     'pullRequestNumber': pullRequestNumber
-  }) as any
+  })
 
   const assert = assertPullRequest.bind(null, {
     owner,

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -8,7 +8,7 @@ import {
   createGithubApiFromPullRequestInfo,
   createApplication,
   createPullRequestOpenedEvent,
-  createGetContent,
+  createGetContents,
   createCheckSuiteCompletedEvent,
   createCheckRunCreatedEvent
 } from './mock'
@@ -126,7 +126,7 @@ it('no configuration should not schedule any pull request', async () => {
 
   const github = createGithubApi({
     repos: {
-      getContent: createGetContent({})
+      getContents: createGetContents({})
     }
   })
 
@@ -268,7 +268,7 @@ it('to report error when processing pull request results in error', async () => 
 
   const github = createGithubApi({
     repos: {
-      getContent: createGetContent({
+      getContents: createGetContents({
         '.github/auto-merge.yml': () => Buffer.from('')
       })
     },

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -8,7 +8,7 @@ import { Config, defaultConfig } from '../src/config'
 import { Application, ApplicationFunction } from 'probot'
 import { GitHubAPI } from 'probot/lib/github'
 import { LoggerWithTarget } from 'probot/lib/wrap-logger'
-import { Response, GitdataDeleteReferenceResponse } from '@octokit/rest'
+import { Response } from '@octokit/rest'
 
 export const defaultPullRequestInfo: PullRequestInfo = {
   number: 1,
@@ -303,7 +303,7 @@ export function createGithubApiFromPullRequestInfo (opts: {
   pullRequestInfo: PullRequestInfo,
   config: string
 }): GitHubAPI {
-  return createPartialGithubApiFromPullRequestInfo(opts) as GitHubAPI
+  return createGithubApi(createPartialGithubApiFromPullRequestInfo(opts))
 }
 
 function createPartialGithubApiFromPullRequestInfo (opts: {
@@ -334,17 +334,17 @@ function createPartialGithubApiFromPullRequestInfo (opts: {
     },
     repos: {
       merge: createOkResponse(),
-      getContent: createGetContent({
+      getContents: createGetContents({
         '.github/auto-merge.yml': () => Buffer.from(opts.config)
       })
     },
     gitdata: {
-      deleteReference: createOkResponse<GitdataDeleteReferenceResponse>()
+      deleteRef: createOkResponse()
     }
   }
 }
 
-export function createGetContent (paths: { [key: string]: () => Buffer }): any {
+export function createGetContents (paths: { [key: string]: () => Buffer }): any {
   return ({ user, repo, path }: { user: string, repo: string, path: string }) => {
     const contentFactory = paths[path]
     if (!contentFactory) {

--- a/test/pull-request-handler.test.ts
+++ b/test/pull-request-handler.test.ts
@@ -260,12 +260,12 @@ describe('executeAction with action', () => {
   })
 
   it('delete_branch', async () => {
-    const deleteReference = jest.fn(() => ({ status: 200 }))
+    const deleteRef = jest.fn(() => ({ status: 200 }))
     await executeAction(
       createPullRequestContext({
         github: createGithubApi({
           gitdata: {
-            deleteReference
+            deleteRef
           }
         })
       }),
@@ -286,8 +286,8 @@ describe('executeAction with action', () => {
       'delete_branch'
     )
 
-    expect(deleteReference).toHaveBeenCalledTimes(1)
-    expect(deleteReference).toBeCalledWith({
+    expect(deleteRef).toHaveBeenCalledTimes(1)
+    expect(deleteRef).toBeCalledWith({
       owner: 'bobvanderlinden',
       repo: 'probot-auto-merge',
       ref: 'heads/the-merged-branch'


### PR DESCRIPTION
This upgrades to probot 7.4.0. Since probot-config is not yet compatible with probot 7.4.0, this also refers to a fixed version of probot-config (https://github.com/probot/probot-config/pull/26).

Since Octokit also upgraded and had several renames, this PR also needed to rename these instances.