### PR TITLE
Continue handling pull request on GraphQL errors

### DIFF
--- a/test/mock.ts
+++ b/test/mock.ts
@@ -355,16 +355,20 @@ export function createGithubApiFromPullRequestInfo (opts: {
   return createGithubApi(createPartialGithubApiFromPullRequestInfo(opts))
 }
 
+export function createPullRequestQuery (pullRequestInfo: PullRequestInfo): PullRequestQuery {
+  return {
+    repository: {
+      __typename: 'Repository',
+      pullRequest: pullRequestInfo as any
+    }
+  }
+}
+
 function createPartialGithubApiFromPullRequestInfo (opts: {
   pullRequestInfo: PullRequestInfo,
   config: string
 }): DeepPartial<GitHubAPI> {
-  const pullRequestQueryResult: PullRequestQuery = {
-    repository: {
-      __typename: 'Repository',
-      pullRequest: opts.pullRequestInfo as any
-    }
-  }
+  const pullRequestQueryResult = createPullRequestQuery(opts.pullRequestInfo)
   return {
     query: jest.fn(() => {
       return pullRequestQueryResult


### PR DESCRIPTION
GraphQL errors happen when parts of a GraphQL query were not allowed or failed. Such an error is thrown on any of such errors, even though most of the resulting response is intact.

Currently auto-merge will halt on any error.

This PR will allow auto-merge to continue handling the PR. If the resulting model passes the validation, everything should be fine.
This PR will still capture such errors in Raven/Sentry for later inspection.