### PR TITLE
Allow not fetching app.id for checkSuites

### DIFF
--- a/src/conditions/blockingChecks.ts
+++ b/src/conditions/blockingChecks.ts
@@ -17,7 +17,7 @@ export default function doesNotHaveBlockingChecks (
           checkSuite
         }))
     )
-  ).filter(checkRun => checkRun.checkSuite.app.id !== myAppId)
+  ).filter(checkRun => (checkRun.checkSuite.app && checkRun.checkSuite.app.id) !== myAppId)
   const allChecksCompleted = checkRuns.every(
     checkRun => checkRun.status === CheckStatusState.COMPLETED
   )

--- a/src/github-models.ts
+++ b/src/github-models.ts
@@ -100,7 +100,7 @@ export function validatePullRequestQuery (pullRequestQuery: PullRequestQuery) {
                     checkSuites: assertNotNullNodes(commit.commit.checkSuites, 'No permission to fetch checkSuites',
                       checkSuite => ({
                         ...removeTypename(checkSuite),
-                        app: assertNotNull(checkSuite.app, 'No permission to fetch app', app => removeTypename(app)),
+                        app: checkSuite.app && removeTypename(checkSuite.app),
                         checkRuns: assertNotNullNodes(checkSuite.checkRuns, 'No permission to fetch checkRuns',
                           checkRun => removeTypename(checkRun)
                         )

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -122,7 +122,7 @@ export function flatMap<TInput, TOutput> (array: Array<TInput>, fn: (input: TInp
 export function getMyCheckSuite (pullRequestInfo: PullRequestInfo) {
   return pullRequestInfo.commits.nodes[0]
     .commit.checkSuites.nodes
-    .filter(checkSuite => checkSuite.app.id === myappid)[0]
+    .filter(checkSuite => (checkSuite.app && checkSuite.app.id) === myappid)[0]
 }
 
 export function getOtherCheckRuns (pullRequestInfo: PullRequestInfo) {
@@ -134,5 +134,5 @@ export function getOtherCheckRuns (pullRequestInfo: PullRequestInfo) {
           checkSuite
         }))
     )
-  ).filter(checkRun => checkRun.checkSuite.app.id !== myappid)
+  ).filter(checkRun => (checkRun.checkSuite.app && checkRun.checkSuite.app.id) !== myappid)
 }


### PR DESCRIPTION
Currently `checkSuites[].app` is required by the query model validation. However, we do not actually need the id in all cases, but only for checkSuites that are owned by `auto-merge`. The validation currently failed, because we do not have permission to fetch the app id of other apps (makes sense, as it is should be private information!).

This PR will remove the hard dependency on app ids of other apps and will allow `app` to be `null`.