### PR TITLE
Avoid capturing errors regarding forbidden checkSuite app

### DIFF
--- a/src/pull-request-query.ts
+++ b/src/pull-request-query.ts
@@ -2,10 +2,36 @@ import { captureException } from 'raven'
 import { PullRequestReference, PullRequestInfo, validatePullRequestQuery } from './github-models'
 import { PullRequestQueryVariables, PullRequestQuery } from './query.graphql'
 import { Context } from 'probot'
-import { GitHubAPI } from 'probot/lib/github'
+import { GitHubAPI, GraphQLQueryError } from 'probot/lib/github'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 const query = readFileSync(join(__dirname, '..', 'query.graphql'), 'utf8')
+
+const isNumber = (v: string | number) => typeof v === 'number'
+type Matcher = string | number | ((v: string | number) => boolean)
+
+function matchPath (expected: Matcher[], actual: (string | number)[]): boolean {
+  const endOfPath = Symbol('endOfPath')
+  const expectedWithEOP = [...expected, endOfPath]
+  const actualWithEOP = [...actual, endOfPath]
+  return expectedWithEOP.every((expectedMatch, index) => {
+    return (typeof expectedMatch === 'function' && expectedMatch(actual[index]))
+      || (expectedMatch === actualWithEOP[index])
+  })
+}
+
+const appPath = [
+  'repository',
+  'pullRequest',
+  'commits',
+  'nodes',
+  isNumber,
+  'commit',
+  'checkSuites',
+  'nodes',
+  isNumber,
+  'app'
+]
 
 async function graphQLQuery (github: GitHubAPI, variables: PullRequestQueryVariables): Promise<PullRequestQuery> {
   try {
@@ -14,8 +40,17 @@ async function graphQLQuery (github: GitHubAPI, variables: PullRequestQueryVaria
     })
   } catch (e) {
     if (e && e.name === 'GraphQLQueryError') {
-      captureException(e)
-      return e.data as PullRequestQuery
+      const queryError = e as GraphQLQueryError
+
+      // Remove error related to permissions for fetching app id of checkSuites.
+      // These errors cannot be  avoided, as auto-merge wants to fetch which checkSuites are its own.
+      // Attemping to fetch other checkSuites, where auto-merge doesn't have permissions for, is an side-effect.
+      const actualErrors = queryError.errors.filter(error => !(error.path && matchPath(appPath, error.path)))
+      if (actualErrors.length > 0) {
+        captureException(queryError)
+      }
+
+      return queryError.data as PullRequestQuery
     } else {
       throw e
     }


### PR DESCRIPTION
Currently there are a lot of errors being captured because auto-merge may not fetch the apps of checkSuites. It was not possible to workaround these errors and we do actually want to know which checkSuite is owned by auto-merge.

This PR will ignore errors regarding checkSuite apps. If there are no other suberror, the graphql error will not be captured.