### PR TITLE
travis: cache npm packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: node_js
 node_js:
 - '8.3'
+cache: npm
 notifications:
   email: false
 


### PR DESCRIPTION
Currently builds take quite a while, because each phase needs to fetch npm packages again. This PR will add npm as a cache for Travis, so that npm packages only need to be fetched once.