### PR TITLE
Update mocks with new package APIs

### DIFF
--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -195,7 +195,7 @@ it('pending check run', async () => {
   expect(github.query).toHaveBeenCalled()
   expect(setTimeout).toHaveBeenCalled()
   expect(github.pullRequests.merge).not.toHaveBeenCalled()
-  github.query = jest.fn(() => {
+  github.query = jest.fn(async () => {
     return {
       repository: {
         pullRequest: {

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -346,8 +346,17 @@ export function createCheckSuiteCompletedEvent (pullRequest: PullRequestReferenc
   }
 }
 
+export function createResponse<T> (options: Partial<Response<T>>): Response<T> {
+  return {
+    data: null,
+    status: 200,
+    headers: {},
+    ...options
+  } as any as Response<T>
+}
+
 export function createOkResponse<T> (): (...args: any[]) => Response<T> {
-  return jest.fn(() => ({ status: 200 }))
+  return jest.fn(() => createResponse({ status: 200 }))
 }
 
 export function createGithubApiFromPullRequestInfo (opts: {


### PR DESCRIPTION
Currently the semaphore build is failing because of invalid type information in the mocks.
This is because type packages for these mocks were updated, but the tests have not.

This PR should resolve these issues.