### PR TITLE
Defer GitHub API creation to PR handlers

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -1,5 +1,13 @@
+import { LoggerWithTarget } from 'probot/lib/wrap-logger'
 import { Context } from 'probot'
 import { Config } from './config'
+import { GitHubAPI } from 'probot/lib/github'
+
+export interface WorkerContext {
+  createGitHubAPI: () => Promise<GitHubAPI>,
+  log: LoggerWithTarget,
+  config: Config
+}
 
 export interface HandlerContext {
   log: Context['log'],

--- a/src/repository-workers.ts
+++ b/src/repository-workers.ts
@@ -1,4 +1,4 @@
-import { HandlerContext } from './models'
+import { WorkerContext } from './models'
 import { RepositoryReference, PullRequestReference } from './github-models'
 import { RepositoryWorker } from './repository-worker'
 
@@ -15,10 +15,18 @@ export class RepositoryWorkers {
     }
   }
 
-  private createRepositoryWorker (repositoryReference: RepositoryReference, context: HandlerContext) {
+  private createRepositoryWorker (repositoryReference: RepositoryReference, context: WorkerContext) {
+    const createGitHubAPI = context.createGitHubAPI
+    const log = context.log
+    const config = context.config
+    const workerContext: WorkerContext = {
+      createGitHubAPI,
+      log,
+      config
+    }
     return new RepositoryWorker(
       repositoryReference,
-      context,
+      workerContext,
       this.onRepositoryWorkerDrained.bind(this, repositoryReference),
       this.onPullRequestError
     )
@@ -29,7 +37,7 @@ export class RepositoryWorkers {
     delete this.repositoryWorkerMap[queueName]
   }
 
-  queue (context: HandlerContext, pullRequestReference: PullRequestReference) {
+  queue (context: WorkerContext, pullRequestReference: PullRequestReference) {
     const queueName = getRepositoryKey(pullRequestReference)
     const repositoryWorker = this.repositoryWorkerMap[queueName] = this.repositoryWorkerMap[queueName] || this.createRepositoryWorker(pullRequestReference, context)
     repositoryWorker.queue(pullRequestReference.number)


### PR DESCRIPTION
Whenever a GitHub API is created, tokens are checked and refreshed. Because GitHub tokens were being used across multiple jobs in a repository-queue, it could happen that the tokens were expired once a job later in the queue was started.

This change makes sure the GitHub API is created when a job is going to be processed. That way the tokens are checked at the beginning of each jobs, instead of at the beginning of the job queue.

It does this by running `app.auth(installationId, log)` each time a job is started in `RepositoryWorker`. `installationId` and `app` are hidden for `RepositoryWorker{s,}` by wrapping the `app.auth` call inside `createGitHubAPI`.