### PR TITLE
Use check databaseId instead of id

### DIFF
--- a/query.graphql
+++ b/query.graphql
@@ -44,13 +44,13 @@ query PullRequestQuery($owner:String!, $repo:String!, $pullRequestNumber:Int!) {
             checkSuites(last: 10) {
               nodes {
                 app {
-                  id
+                  databaseId
                 }
                 status
                 conclusion
                 checkRuns(last: 10) {
                   nodes {
-                    id
+                    databaseId
                     name
                     conclusion
                     status

--- a/src/conditions/blockingChecks.ts
+++ b/src/conditions/blockingChecks.ts
@@ -17,7 +17,7 @@ export default function doesNotHaveBlockingChecks (
           checkSuite
         }))
     )
-  ).filter(checkRun => (checkRun.checkSuite.app && checkRun.checkSuite.app.id) !== myAppId)
+  ).filter(checkRun => (checkRun.checkSuite.app && checkRun.checkSuite.app.databaseId) !== myAppId)
   const allChecksCompleted = checkRuns.every(
     checkRun => checkRun.status === CheckStatusState.COMPLETED
   )

--- a/src/github-models.ts
+++ b/src/github-models.ts
@@ -102,7 +102,10 @@ export function validatePullRequestQuery (pullRequestQuery: PullRequestQuery) {
                         ...removeTypename(checkSuite),
                         app: checkSuite.app && removeTypename(checkSuite.app),
                         checkRuns: assertNotNullNodes(checkSuite.checkRuns, 'No permission to fetch checkRuns',
-                          checkRun => removeTypename(checkRun)
+                          checkRun => ({
+                            ...removeTypename(checkRun),
+                            databaseId: assertNotNull(checkRun.databaseId, 'No permission to fetch databaseId for checkRun', databaseId => databaseId)
+                          })
                         )
                       })
                     )

--- a/src/myappid.ts
+++ b/src/myappid.ts
@@ -1,11 +1,11 @@
 function getMyAppId () {
   if (process.env.APP_ID) {
-    return process.env.APP_ID
+    return parseInt(process.env.APP_ID, 10)
   }
   if (process.env.NODE_ENV === 'production') {
     throw new Error('No APP_ID defined!')
   }
-  return '1'
+  return 1
 }
 
 export default getMyAppId()

--- a/src/query.graphql.ts
+++ b/src/query.graphql.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -111,12 +112,18 @@ export interface PullRequestQuery_repository_pullRequest_baseRef {
 
 export interface PullRequestQuery_repository_pullRequest_commits_nodes_commit_checkSuites_nodes_app {
   __typename: "App";
-  id: string;
+  /**
+   * Identifies the primary key from the database.
+   */
+  databaseId: number | null;
 }
 
 export interface PullRequestQuery_repository_pullRequest_commits_nodes_commit_checkSuites_nodes_checkRuns_nodes {
   __typename: "CheckRun";
-  id: string;
+  /**
+   * Identifies the primary key from the database.
+   */
+  databaseId: number | null;
   /**
    * The name of the check for this check run.
    */
@@ -360,6 +367,7 @@ export interface PullRequestQueryVariables {
 }
 
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 //==============================================================

--- a/src/status-report.ts
+++ b/src/status-report.ts
@@ -39,7 +39,7 @@ export async function updateStatusReportCheck (
     // Whenever we find an existing check_run from this app,
     // we will update that check_run.
     await context.github.checks.update({
-      check_run_id: parseInt(myCheckRun.id, 10),
+      check_run_id: myCheckRun.databaseId,
       ...checkOptions
     })
   } else if (context.config.reportStatus) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -122,7 +122,7 @@ export function flatMap<TInput, TOutput> (array: Array<TInput>, fn: (input: TInp
 export function getMyCheckSuite (pullRequestInfo: PullRequestInfo) {
   return pullRequestInfo.commits.nodes[0]
     .commit.checkSuites.nodes
-    .filter(checkSuite => (checkSuite.app && checkSuite.app.id) === myappid)[0]
+    .filter(checkSuite => (checkSuite.app && checkSuite.app.databaseId) === myappid)[0]
 }
 
 export function getOtherCheckRuns (pullRequestInfo: PullRequestInfo) {
@@ -134,5 +134,5 @@ export function getOtherCheckRuns (pullRequestInfo: PullRequestInfo) {
           checkSuite
         }))
     )
-  ).filter(checkRun => (checkRun.checkSuite.app && checkRun.checkSuite.app.id) !== myappid)
+  ).filter(checkRun => (checkRun.checkSuite.app && checkRun.checkSuite.app.databaseId) !== myappid)
 }

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -147,7 +147,7 @@ export const changesRequestedReview = (options?: Partial<Review>) =>
 
 export function createCheckRun (options?: Partial<CheckRun>): CheckRun {
   return {
-    id: '123',
+    databaseId: 123,
     name: 'checka',
     status: CheckStatusState.COMPLETED,
     conclusion: CheckConclusionState.SUCCESS,
@@ -263,7 +263,7 @@ export function createCommit (options?: Partial<Commit>): { commit: Commit } {
 export function createCheckSuite (options?: Partial<CheckSuite>): CheckSuite {
   return {
     app: {
-      id: '123'
+      databaseId: 123
     },
     conclusion: CheckConclusionState.SUCCESS,
     status: CheckStatusState.COMPLETED,

--- a/test/status-report.test.ts
+++ b/test/status-report.test.ts
@@ -2,12 +2,12 @@ import { CheckSuite } from './../src/github-models'
 import { createPullRequestInfo, createPullRequestContext, createGithubApi, createCheckRun, createConfig, createCheckSuite, createCommit } from './mock'
 import { updateStatusReportCheck } from '../src/status-report'
 
-const myappid = '1'
+const myappid = 1
 
 function createOtherAppCheckSuite (options?: Partial<CheckSuite>) {
   return createCheckSuite({
     app: {
-      id: '123'
+      databaseId: 123
     },
     checkRuns: {
       nodes: [createCheckRun()]
@@ -19,7 +19,7 @@ function createOtherAppCheckSuite (options?: Partial<CheckSuite>) {
 function createMyCheckSuite (options?: Partial<CheckSuite>) {
   return createCheckSuite({
     app: {
-      id: myappid
+      databaseId: myappid
     },
     checkRuns: {
       nodes: [createCheckRun()]


### PR DESCRIPTION
The GraphQL schema seemed to have changed. Earlier the app `id` of checkSuite and checkRun models was the stringified `APP_ID`. Now, that `id` no longer contains a number. This results in very strange behavior, because auto-merge was not able to filter its own check-events nor see which checks belong to itself (to update them).

This PR will change the usage of `id` to `databaseId`. Since this field is now numeric, we no longer not have to stringify `APP_ID`.