### PR TITLE
Queue improvements

### DIFF
--- a/src/WaitQueue.ts
+++ b/src/WaitQueue.ts
@@ -106,6 +106,17 @@ export class WaitQueue<T> {
     }
   }
 
+  public queue (work: T) {
+    const workId = this.getId(work)
+    if (this.runningTask !== null &&
+      this.runningTask.task.id === workId) {
+      // Currently handling this task. Reschedule this work on top.
+      this.queueFirst(work)
+    } else {
+      this.queueLast(work)
+    }
+  }
+
   public currentTask (): WaitQueueTask<T> | null {
     return this.runningTask && this.runningTask.task
   }

--- a/src/WaitQueue.ts
+++ b/src/WaitQueue.ts
@@ -97,10 +97,11 @@ export class WaitQueue<T> {
   public queueLast (work: T, delay: number = 0) {
     this.queueTaskLast(this.createTasks(work, delay))
   }
-  public stopWaitingFor (id: string) {
+  public stopWaitingFor (work: T) {
+    const workId = this.getId(work)
     if (this.runningTask !== null &&
       this.runningTask.task.type === 'wait' &&
-      this.runningTask.task.id === id &&
+      this.runningTask.task.id === workId &&
       this.runningTask.promise.cancel) {
       this.runningTask.promise.cancel()
     }

--- a/src/repository-worker.ts
+++ b/src/repository-worker.ts
@@ -48,7 +48,7 @@ export class RepositoryWorker {
   }
 
   public queue (pullRequestNumber: number) {
-    this.waitQueue.stopWaitingFor(`${pullRequestNumber}`)
+    this.waitQueue.stopWaitingFor(pullRequestNumber)
     this.waitQueue.queue(pullRequestNumber)
     this.context.log.debug(`Queued ${pullRequestNumber}`, {
       current: this.waitQueue.currentTask(),

--- a/src/repository-worker.ts
+++ b/src/repository-worker.ts
@@ -49,7 +49,7 @@ export class RepositoryWorker {
 
   public queue (pullRequestNumber: number) {
     this.waitQueue.stopWaitingFor(`${pullRequestNumber}`)
-    this.waitQueue.queueLast(pullRequestNumber)
+    this.waitQueue.queue(pullRequestNumber)
     this.context.log.debug(`Queued ${pullRequestNumber}`, {
       current: this.waitQueue.currentTask(),
       queued: this.waitQueue.getQueuedTasks()


### PR DESCRIPTION
Currently the queue has problems handling PRs in sequence. This happens when a PR is currently being handled while events for the same PR are coming in. These events result in jobs being queued at the end of the queue. Therefore other PRs will sometimes be handled earlier even though the current PR is in pending state.

This PR will always queue PRs on top whenever the PR is currently being handled.

In addition a small refactoring of stopWaitingfor.