### PR TITLE
Include response in error context

### DIFF
--- a/src/pull-request-query.ts
+++ b/src/pull-request-query.ts
@@ -1,4 +1,4 @@
-import { captureException } from 'raven'
+import { captureException, context } from 'raven'
 import { PullRequestReference, PullRequestInfo, validatePullRequestQuery } from './github-models'
 import { PullRequestQueryVariables, PullRequestQuery } from './query.graphql'
 import { Context } from 'probot'
@@ -64,7 +64,10 @@ export async function queryPullRequest (github: Context['github'], { owner, repo
     'pullRequestNumber': pullRequestNumber
   })
 
-  const checkedResponse = validatePullRequestQuery(response)
-
-  return checkedResponse.repository.pullRequest
+  return context({
+    extras: { response }
+  }, () => {
+    const checkedResponse = validatePullRequestQuery(response)
+    return checkedResponse.repository.pullRequest
+  })
 }

--- a/src/pull-request-query.ts
+++ b/src/pull-request-query.ts
@@ -1,4 +1,4 @@
-import { captureException, context } from 'raven'
+import Raven from 'raven'
 import { PullRequestReference, PullRequestInfo, validatePullRequestQuery } from './github-models'
 import { PullRequestQueryVariables, PullRequestQuery } from './query.graphql'
 import { Context } from 'probot'
@@ -47,7 +47,7 @@ async function graphQLQuery (github: GitHubAPI, variables: PullRequestQueryVaria
       // Attemping to fetch other checkSuites, where auto-merge doesn't have permissions for, is an side-effect.
       const actualErrors = queryError.errors.filter(error => !(error.path && matchPath(appPath, error.path)))
       if (actualErrors.length > 0) {
-        captureException(queryError)
+        Raven.captureException(queryError)
       }
 
       return queryError.data as PullRequestQuery
@@ -64,7 +64,7 @@ export async function queryPullRequest (github: Context['github'], { owner, repo
     'pullRequestNumber': pullRequestNumber
   })
 
-  return context({
+  return Raven.context({
     extras: { response }
   }, () => {
     const checkedResponse = validatePullRequestQuery(response)

--- a/test/jest-setup.ts
+++ b/test/jest-setup.ts
@@ -1,3 +1,7 @@
+import Raven from 'raven'
+
+Raven.config('https://123@sentry.io/123').install()
+
 process.on('unhandledRejection', reason => {
   throw reason
 })


### PR DESCRIPTION
Currently, validation errors do not include information about the query response itself. It is insightful to know _why_ validation errors are happening and the GraphQL query response will help with that.

This PR will add the response to Ravens error context.