### PR TITLE
Handle null and unrecognized merge states

### DIFF
--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -63,6 +63,7 @@ export type PullRequestActions
 
 export type PullRequestPlanCode
   = 'mergeable_unknown'
+  | 'mergeable_not_supplied'
   | 'pending_condition'
   | 'failing_condition'
   | 'blocked'
@@ -180,6 +181,12 @@ export function getPullRequestPlan (
           message: 'Will merge the pull request',
           actions: ['merge']
         }
+      }
+    case null:
+      return {
+        code: 'mergeable_not_supplied',
+        message: 'GitHub did not provide merge state of PR',
+        actions: ['reschedule']
       }
   }
 }

--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -188,6 +188,11 @@ export function getPullRequestPlan (
         message: 'GitHub did not provide merge state of PR',
         actions: ['reschedule']
       }
+    default:
+      Raven.mergeContext({
+        extras: { pullRequestInfo }
+      })
+      throw new Error(`Merge state (${pullRequestInfo.mergeStateStatus}) was not recognized`)
   }
 }
 


### PR DESCRIPTION
Currently it could happen that the merge state, as supplied by GitHub, is null _or_ that the merge state is one that auto-merge does not (yet) recognize. In these cases the bot would fail at a later stage where it was not clear which merge state was supplied by GitHub.

This PR will now reschedule the PR when the mergeState is null (GitHub probably needs to evaluate the merge-state still). In addition, this PR will add additional information for merge-state errors when the merge-state is not recognized by auto-merge.