### PR TITLE
Always supply text for checks

### DIFF
--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -228,7 +228,7 @@ export async function executeActions (
     try {
       await executeAction(context, pullRequestInfo, action)
     } catch (err) {
-      await updateStatusReportCheck(context, pullRequestInfo, `Failed to ${getPullRequestActionName(action)}`, err.toString())
+      await updateStatusReportCheck(context, pullRequestInfo, `Failed to ${getPullRequestActionName(action)}`, err.toString(), err.toString())
       throw err
     }
   }
@@ -321,7 +321,12 @@ export async function handlePullRequestStatus (
       : plan.actions.some(action => action === 'reschedule')
       ? 'Waiting'
       : 'Not merging',
-    plan.message
+    plan.message,
+    `${plan.message}
+<!--
+${JSON.stringify(plan)}
+-->
+`
   )
 
   const { actions } = plan

--- a/src/status-report.ts
+++ b/src/status-report.ts
@@ -7,7 +7,8 @@ export async function updateStatusReportCheck (
   context: PullRequestContext,
   pullRequestInfo: PullRequestInfo,
   title: string,
-  summary: string
+  summary: string,
+  text: string
 ) {
   const myCheckSuite = getMyCheckSuite(pullRequestInfo)
   const myCheckRun = myCheckSuite && myCheckSuite.checkRuns.nodes[0]
@@ -29,7 +30,8 @@ export async function updateStatusReportCheck (
     completed_at: new Date().toISOString(),
     output: {
       title,
-      summary
+      summary,
+      text
     },
     owner: pullRequestInfo.baseRef.repository.owner.login,
     repo: pullRequestInfo.baseRef.repository.name

--- a/test/status-report.test.ts
+++ b/test/status-report.test.ts
@@ -92,7 +92,7 @@ describe('updateStatusReportCheck', () => {
       ]
     })
 
-    await updateStatusReportCheck(context, pullRequestInfo, 'mytitle', 'mysummary')
+    await updateStatusReportCheck(context, pullRequestInfo, 'mytitle', 'mysummary', 'mytext')
 
     expect(updateCheck).toBeCalled()
   })
@@ -109,7 +109,7 @@ describe('updateStatusReportCheck', () => {
       ]
     })
 
-    await updateStatusReportCheck(context, pullRequestInfo, 'mytitle', 'mysummary')
+    await updateStatusReportCheck(context, pullRequestInfo, 'mytitle', 'mysummary', 'mytext')
 
     expect(createCheck).toBeCalled()
   })
@@ -127,7 +127,7 @@ describe('updateStatusReportCheck', () => {
       ]
     })
 
-    await updateStatusReportCheck(context, pullRequestInfo, 'mytitle', 'mysummary')
+    await updateStatusReportCheck(context, pullRequestInfo, 'mytitle', 'mysummary', 'mytext')
 
     expect(createCheck).not.toBeCalled()
     expect(updateCheck).not.toBeCalled()
@@ -146,7 +146,7 @@ describe('updateStatusReportCheck', () => {
       ]
     })
 
-    await updateStatusReportCheck(context, pullRequestInfo, 'mytitle', 'mysummary')
+    await updateStatusReportCheck(context, pullRequestInfo, 'mytitle', 'mysummary', 'mytext')
 
     expect(createCheck).not.toBeCalled()
     expect(updateCheck).toBeCalled()


### PR DESCRIPTION
This will use the `text` field for checks next to just the `summary` and `title`. In addition, it will add the raw PullRequestPlan in the comments of the text, so that all information _could_ be seen when showing details of the auto-merge check.