### PR TITLE
Prometheus metrics reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2540,6 +2540,11 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "body-parser": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
@@ -12996,6 +13001,14 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "prom-client": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.3.0.tgz",
+      "integrity": "sha512-OqSf5WOvpGZXkfqPXUHNHpjrbEE/q8jxjktO0i7zg1cnULAtf0ET67/J5R4e4iA4MZx2260tzTzSFSWgMdTZmQ==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "promise-events": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/promise-events/-/promise-events-0.1.4.tgz",
@@ -14710,6 +14723,14 @@
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         }
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
       }
     },
     "teeny-request": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "minimatch": "^3.0.4",
     "probot": "^7.4.0",
     "probot-config": "^1.0.1",
+    "prom-client": "^11.3.0",
     "raven": "^2.6.4"
   },
   "devDependencies": {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,44 @@
+import promClient, { Gauge, labelValues } from 'prom-client'
+
+const makeMockGauge = (name: String): Partial<Gauge> => ({
+  set: (labels: labelValues | number, value: number) => {} // tslint:disable-line:no-empty
+})
+
+class MetricsReporter {
+  public rateLimitGauge: Gauge
+  public queueSizeGauge: Gauge
+
+  constructor (public enabled: boolean) {
+    this.enabled = enabled
+
+    if (this.enabled) {
+      promClient.collectDefaultMetrics()
+
+      this.rateLimitGauge = new promClient.Gauge({
+        name: 'probot_auto_merge_github_rate_limit_remaining',
+        help:
+          'Github rate limit as reported by the `x-ratelimit-remaining` header',
+        labelNames: ['owner', 'repo', 'apiVersion']
+      })
+
+      this.queueSizeGauge = new promClient.Gauge({
+        name: 'probot_auto_merge_pr_queue_size',
+        help: 'Number of PRs in the Probot Auto Merge queue',
+        labelNames: ['owner', 'repo']
+      })
+    } else {
+      this.rateLimitGauge = makeMockGauge('rate limit') as Gauge
+      this.queueSizeGauge = makeMockGauge('queue size') as Gauge
+    }
+  }
+
+  outputMetrics (): string {
+    return this.enabled ? promClient.register.metrics() : 'nothing'
+  }
+}
+
+const metricsReporter = new MetricsReporter(
+  process.env.NODE_ENV === 'production'
+)
+
+export { metricsReporter }

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -78,7 +78,15 @@ export function createPullRequestInfo (pullRequestInfo?: Partial<PullRequestInfo
 
 export function createGithubApi (options?: DeepPartial<GitHubAPI>): GitHubAPI {
   return {
-    ...options
+    ...options,
+    hook: {
+      before: (when: string, cb: () => void) => {
+        return
+      },
+      after: (when: string, cb: () => void) => {
+        return
+      }
+    }
   } as GitHubAPI
 }
 


### PR DESCRIPTION
## What is this?

This change adds metrics reporting using a [Prometheus](https://prometheus.io/) client ([prom-client](https://github.com/siimon/prom-client)).

Two metrics are being tracked:

1. Github API rate limit (as reported by their rate limit remaining headers)
2. Size of PR queue

The metrics are segmented by owner/repo combo.

The app exposes a `/metrics` endpoint which a Prometheus server consumes and turns into a time series.

See #240 for a screenshot.