### PR TITLE
nix: use shell helper function

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,5 @@
 { pkgs ? import <nixpkgs> { } }:
 with pkgs;
-stdenv.mkDerivation {
-  name = "probot-auto-merge";
+mkShell {
   buildInputs = [ heroku nodejs-10_x python ];
 }


### PR DESCRIPTION
Use `shell` function of Nixpkgs instead of using `mkDerivation`.