### PR TITLE
Do not count COMMENTED reviews as review decisions

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,10 +94,9 @@ export function get<TKey extends string, TValue> (obj: { [key in TKey]: TValue }
 }
 
 export function getLatestReviews (pullRequestInfo: PullRequestInfo) {
-  const sortedReviews = pullRequestInfo.reviews.nodes.sort(
-    (a, b) =>
-      new Date(a.submittedAt).getTime() - new Date(b.submittedAt).getTime()
-  )
+  const sortedReviews = pullRequestInfo.reviews.nodes
+    .filter(review => review.state !== 'COMMENTED')
+    .sort((a, b) => new Date(a.submittedAt).getTime() - new Date(b.submittedAt).getTime())
   const latestReviewsByUser = groupByLast(
     review => review.author.login,
     sortedReviews


### PR DESCRIPTION
Currently COMMENTED reviews are also counted as decisions when determining whether a reviewer approved or declined a PR.
Whenever a reviewer first approved a PR and afterwards did a comment-review, the comment-review overwrote the approval decision.
This does not reflect the behaviour seen in GitHub.

This PR will ignore comment-reviews so that they do not overwrite decisions.