### PR TITLE
Fix Raven incorrect contexts for error reports

### DIFF
--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -190,7 +190,7 @@ export function getPullRequestPlan (
       }
     default:
       Raven.mergeContext({
-        extras: { pullRequestInfo }
+        extra: { pullRequestInfo }
       })
       throw new Error(`Merge state (${pullRequestInfo.mergeStateStatus}) was not recognized`)
   }

--- a/src/pull-request-query.ts
+++ b/src/pull-request-query.ts
@@ -64,10 +64,9 @@ export async function queryPullRequest (github: Context['github'], { owner, repo
     'pullRequestNumber': pullRequestNumber
   })
 
-  return Raven.context({
+  const checkedResponse = Raven.context({
     extra: { response }
-  }, () => {
-    const checkedResponse = validatePullRequestQuery(response)
-    return checkedResponse.repository.pullRequest
-  })
+  }, () => validatePullRequestQuery(response))
+
+  return checkedResponse.repository.pullRequest
 }

--- a/src/pull-request-query.ts
+++ b/src/pull-request-query.ts
@@ -65,7 +65,7 @@ export async function queryPullRequest (github: Context['github'], { owner, repo
   })
 
   return Raven.context({
-    extras: { response }
+    extra: { response }
   }, () => {
     const checkedResponse = validatePullRequestQuery(response)
     return checkedResponse.repository.pullRequest


### PR DESCRIPTION
Currently error reports using Raven are less than ideal:

* Validation errors do not have information about the validated data.
* Contexts inbetween handling PRs is leaking to error reports of eachother.
* Some errors did not have extra information.

These issues were resolved in this PR.