### PR TITLE
remove unused headSha from event handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export = (app: Application) => {
     console.error(`Error while processing pull request ${pullRequestName}:`, error)
   }
 
-  async function handlePullRequests (app: Application, context: Context, installationId: number, repository: RepositoryReference, headSha: string, pullRequestNumbers: number[]) {
+  async function handlePullRequests (app: Application, context: Context, installationId: number, repository: RepositoryReference, pullRequestNumbers: number[]) {
     await useWorkerContext({ app, context, installationId }, async (workerContext) => {
       for (let pullRequestNumber of pullRequestNumbers) {
         repositoryWorkers.queue(workerContext, {
@@ -105,7 +105,7 @@ export = (app: Application) => {
     await handlePullRequests(app, context, context.payload.installation.id, {
       owner: context.payload.repository.owner.login,
       repo: context.payload.repository.name
-    }, context.payload.pull_request.head_sha, [context.payload.pull_request.number])
+    }, [context.payload.pull_request.number])
   })
 
   app.on([
@@ -119,7 +119,7 @@ export = (app: Application) => {
     await handlePullRequests(app, context, context.payload.installation.id, {
       owner: context.payload.repository.owner.login,
       repo: context.payload.repository.name
-    }, context.payload.check_run.head_sha, context.payload.check_run.pull_requests.map((pullRequest: any) => pullRequest.number))
+    }, context.payload.check_run.pull_requests.map((pullRequest: any) => pullRequest.number))
   })
 
   app.on([
@@ -129,7 +129,7 @@ export = (app: Application) => {
     await handlePullRequests(app, context, context.payload.installation.id, {
       owner: context.payload.repository.owner.login,
       repo: context.payload.repository.name
-    }, context.payload.check_run.head_sha, context.payload.check_run.pull_requests.map((pullRequest: any) => pullRequest.number))
+    }, context.payload.check_run.pull_requests.map((pullRequest: any) => pullRequest.number))
   })
 
   app.on([
@@ -139,7 +139,7 @@ export = (app: Application) => {
     await handlePullRequests(app, context, context.payload.installation.id, {
       owner: context.payload.repository.owner.login,
       repo: context.payload.repository.name
-    }, context.payload.check_suite.head_sha, context.payload.check_suite.pull_requests.map((pullRequest: any) => pullRequest.number))
+    }, context.payload.check_suite.pull_requests.map((pullRequest: any) => pullRequest.number))
   })
 
   app.on([
@@ -148,6 +148,6 @@ export = (app: Application) => {
     await handlePullRequests(app, context, context.payload.installation.id, {
       owner: context.payload.repository.owner.login,
       repo: context.payload.repository.name
-    }, context.payload.check_suite.head_sha, context.payload.check_suite.pull_requests.map((pullRequest: any) => pullRequest.number))
+    }, context.payload.check_suite.pull_requests.map((pullRequest: any) => pullRequest.number))
   })
 }


### PR DESCRIPTION
Currently headSha is picked from the events, but this value is not actually used anywhere. This may be removed.