### PR TITLE
Fix the Github link

### DIFF
--- a/auto-merge.example.yml
+++ b/auto-merge.example.yml
@@ -2,7 +2,7 @@
 
 # The minimum number of reviews from each association that approve the pull request before
 # doing an automatic merge. For more information about associations see:
-# https://developer.github.com/v4/reference/enum/commentauthorassociation/
+# https://developer.github.com/v4/enum/commentauthorassociation/
 minApprovals:
   MEMBER: 1
   COLLABORATOR: 2


### PR DESCRIPTION
Working link: https://developer.github.com/v4/enum/commentauthorassociation/