### PR TITLE
Make use of status check events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import Raven from 'raven'
 import { RepositoryWorkers } from './repository-workers'
 import sentryStream from 'bunyan-sentry-stream'
 import { RepositoryReference, PullRequestReference } from './github-models'
-import { queryPullRequestsForBranch } from './pull-request-query'
 import myAppId from './myappid'
 import { flatten } from './utils'
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,6 +114,8 @@ export function mapObject<TKey extends string, TValue, TMappedValue> (obj: { [ke
   return result
 }
 
+export function flatten<T> (arrays: T[][]): T[] { return ([] as T[]).concat.apply([], arrays) }
+
 export function flatMap<TInput, TOutput> (array: Array<TInput>, fn: (input: TInput) => Array<TOutput>): Array<TOutput> {
   return array.reduce<Array<TOutput>>((result, input) => [...result, ...fn(input)], [])
 }

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -269,7 +269,7 @@ export function createStatusEvent (options: RepositoryReference & { sha: string,
           login: options.owner
         },
         name: options.repo
-      },
+      }
     }
   }
 }

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -1,6 +1,6 @@
 import { PullRequestContext } from './../src/pull-request-handler'
 import { ConditionConfig, defaultRuleConfig } from './../src/config'
-import { Review, CheckRun, PullRequestReviewState, Ref, CheckStatusState, CheckConclusionState, CheckSuite, Commit } from './../src/github-models'
+import { Review, CheckRun, PullRequestReviewState, Ref, CheckStatusState, CheckConclusionState, CheckSuite, Commit, RepositoryReference } from './../src/github-models'
 import { HandlerContext, PullRequestReference, PullRequestState, MergeableState, CommentAuthorAssociation } from './../src/models'
 import { PullRequestInfo } from '../src/models'
 import { Config, defaultConfig } from '../src/config'
@@ -249,6 +249,31 @@ export function createPullRequestOpenedEvent (pullRequest: PullRequestReference)
   }
 }
 
+export function createStatusEvent (options: RepositoryReference & { sha: string, branchName: string }): any {
+  return {
+    name: 'status',
+    payload: {
+      installation: 1,
+      sha: options.sha,
+      state: 'success',
+      description: 'This is a status check',
+      branches: [{
+        name: options.branchName,
+        commit: {
+          sha: options.sha
+        },
+        protected: false
+      }],
+      repository: {
+        owner: {
+          login: options.owner
+        },
+        name: options.repo
+      },
+    }
+  }
+}
+
 export function createCommit (options?: Partial<Commit>): { commit: Commit } {
   return {
     commit: {
@@ -389,7 +414,8 @@ function createPartialGithubApiFromPullRequestInfo (opts: {
       update: jest.fn()
     },
     pullRequests: {
-      merge: createOkResponse()
+      merge: createOkResponse(),
+      list: createOkResponse()
     },
     repos: {
       merge: createOkResponse(),


### PR DESCRIPTION
Follow-up from #275

Currently probot-auto-merge does not handle status check events.
That means it misses pull request changes which leads to delayed handling of PRs.

#275 made use of GraphQL to fetch the related pull request numbers from the branch name that status events supply.
This PR changes that and directly uses the GitHub API. This avoids GraphQL to TypeScript conversion steps.

In addition, this PR adds an integration test that checks merging is possible when handling pull requests in respond to status events.

To avoid unnecessary API calls we are ignoring the `master` branch. We presume the `master` branch will never be used for pull requests source branch.