### PR TITLE
add dotenv to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4055,8 +4055,7 @@
     "dotenv": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.1.0.tgz",
-      "integrity": "sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==",
-      "dev": true
+      "integrity": "sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA=="
     },
     "dtrace-provider": {
       "version": "0.8.8",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@mojotech/json-type-validation": "^3.1.0",
     "bunyan-sentry-stream": "^1.2.1",
     "debug": "^4.1.1",
+    "dotenv": "^8.1.0",
     "minimatch": "^3.0.4",
     "probot": "^9.3.1",
     "probot-config": "^1.0.1",

--- a/src/pull-request-query.ts
+++ b/src/pull-request-query.ts
@@ -34,8 +34,11 @@ const appPath = [
 ]
 
 async function graphQLQuery (github: GitHubAPI, variables: PullRequestQueryVariables): Promise<PullRequestQuery> {
-  const response = await github.graphql(query, variables, {
-    'Accept': 'application/vnd.github.antiope-preview+json, application/vnd.github.merge-info-preview+json'
+  const response = await github.graphql(query, {
+    ...variables,
+    headers: {
+      'Accept': 'application/vnd.github.antiope-preview+json, application/vnd.github.merge-info-preview+json'
+    }
   })
   if (response.errors) {
     // Remove error related to permissions for fetching app id of checkSuites.


### PR DESCRIPTION
Currently Heroku is not able to start the server because it cannot find the `dotenv` package. It is still unknown to me why Heroku is not able to find this package, as `probot` does list it in its dependencies.

Adding the dependency explicitly to probot-auto-merge's package.json resolves the problem for now, so that is what this PR does.