### PR TITLE
Work around graphql query incorrect type signature

### DIFF
--- a/test/mock.ts
+++ b/test/mock.ts
@@ -11,6 +11,17 @@ import { Response, Endpoint } from '@octokit/rest'
 import { DeepPartial, Omit } from '../src/type-utils'
 import { PullRequestQuery, MergeStateStatus } from '../src/query.graphql'
 
+export class GraphqlError {
+  name: string
+  errors?: any
+  data?: any
+  constructor (options: { errors?: any, data?: any }) {
+    this.name = 'GraphqlError'
+    this.errors = options.errors
+    this.data = options.data
+  }
+}
+
 export const defaultPullRequestInfo = {
   number: 1,
   state: PullRequestState.OPEN,
@@ -422,9 +433,7 @@ function createPartialGithubApiFromPullRequestInfo (opts: {
   const pullRequestQueryResult = createPullRequestQuery(opts.pullRequestInfo)
   return {
     graphql: jest.fn(() => {
-      return {
-        data: pullRequestQueryResult
-      }
+      return pullRequestQueryResult
     }),
     checks: {
       create: createOkResponse(),

--- a/test/pull-request-query.test.ts
+++ b/test/pull-request-query.test.ts
@@ -1,15 +1,13 @@
 import { queryPullRequest } from '../src/pull-request-query'
-import { createGithubApi, createPullRequestInfo, createPullRequestQuery, createOkEndpoint } from './mock'
+import { createGithubApi, createPullRequestInfo, createPullRequestQuery, createOkEndpoint, GraphqlError } from './mock'
 
 describe('queryPullRequest', () => {
   it('should do a single graphql query', async () => {
     const pullRequestInfo = createPullRequestInfo()
     const graphql = jest.fn(() => ({
-      data: {
-        repository: {
-          pullRequest: {
-            ...pullRequestInfo
-          }
+      repository: {
+        pullRequest: {
+          ...pullRequestInfo
         }
       }
     }))
@@ -31,9 +29,7 @@ describe('queryPullRequest', () => {
   })
 
   it('should throw error when no query response', async () => {
-    const graphql = jest.fn(() => ({
-      data: null
-    }))
+    const graphql = jest.fn(() => null)
     expect(queryPullRequest(
       createGithubApi({
         graphql
@@ -43,9 +39,7 @@ describe('queryPullRequest', () => {
   })
 
   it('should throw error when empty query response', async () => {
-    const graphql = jest.fn(() => ({
-      data: {}
-    }))
+    const graphql = jest.fn(() => ({}))
     expect(queryPullRequest(
       createGithubApi({
         graphql
@@ -77,7 +71,7 @@ describe('queryPullRequest', () => {
     Raven.captureException = captureException
     const queryResult = createPullRequestQuery(createPullRequestInfo())
     const graphql = jest.fn(() => {
-      return {
+      throw new GraphqlError({
         errors: [{
           extensions: [],
           locations: [],
@@ -85,7 +79,7 @@ describe('queryPullRequest', () => {
           path: ['repository', 'some', 'field']
         }],
         data: queryResult
-      }
+      })
     })
     await queryPullRequest(
       createGithubApi({
@@ -102,7 +96,7 @@ describe('queryPullRequest', () => {
     Raven.captureException = captureException
     const queryResult = createPullRequestQuery(createPullRequestInfo())
     const graphql = jest.fn(() => {
-      return {
+      throw new GraphqlError({
         errors: [{
           extensions: [],
           locations: [],
@@ -121,7 +115,7 @@ describe('queryPullRequest', () => {
           ]
         }],
         data: queryResult
-      }
+      })
     })
     await queryPullRequest(
       createGithubApi({


### PR DESCRIPTION
After the upgrade of probot, the type signature of the graphql call has changed. `probot-auto-merge` made use of that new type signature, however it now showed that even though the typesignature has changed, the actual values returned have not.

This caused auto-merge to not be able to query any repositories anymore.

This PR works around the issue by introducing a function that wraps the incorrect function. The new function has the right type signature.