### PR TITLE
Use associatedPullRequests for status events

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,0 @@
-# These are supported funding model platforms
-
-github: [bobvanderlinden]
-patreon: [bobvanderlinden@gmail.com]

--- a/src/github-utils.ts
+++ b/src/github-utils.ts
@@ -1,5 +1,5 @@
-import { GitHubAPI } from "probot/lib/github"
-import { GraphQlQueryResponse } from "@octokit/graphql/dist-types/types"
+import { GitHubAPI } from 'probot/lib/github'
+import { GraphQlQueryResponse } from '@octokit/graphql/dist-types/types'
 
 export async function rawGraphQLQuery (github: GitHubAPI, query: string, variables: { [key in string]: any }, headers: { [key in string]: string }): Promise<GraphQlQueryResponse> {
   try {

--- a/src/github-utils.ts
+++ b/src/github-utils.ts
@@ -1,0 +1,27 @@
+import { GitHubAPI } from "probot/lib/github"
+import { GraphQlQueryResponse } from "@octokit/graphql/dist-types/types"
+
+export async function rawGraphQLQuery (github: GitHubAPI, query: string, variables: { [key in string]: any }, headers: { [key in string]: string }): Promise<GraphQlQueryResponse> {
+  try {
+    // Warning: The type signature of the graphql call is incorrect. It actually returns the data of the graphql response.
+    // the errors are passed by throwing an exception.
+    const data = await github.graphql(query, {
+      ...variables,
+      headers
+    }) as any
+    return {
+      data
+    }
+  } catch (e) {
+    if (e && e.name === 'GraphqlError') {
+      const errors = e.errors
+      const data = e.data
+      return {
+        data,
+        errors
+      }
+    } else {
+      throw e
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ export = (app: Application) => {
       context.github.pulls.list({
         owner: repositoryReference.owner,
         repo: repositoryReference.repo,
-        base: branch.name
+        head: `${repositoryReference.owner}:${branch.name}`
       })
     ))
     const pullRequests = flatten(pullRequestResponses.map(response => response.data))

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -237,7 +237,7 @@ it('merges when receiving status event', async () => {
   )
   expect(github.pulls.merge).toHaveBeenCalledWith({
     merge_method: 'merge',
-    number: 1,
+    pull_number: 1,
     owner: 'bobvanderlinden',
     repo: 'probot-auto-merge'
   })

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -177,27 +177,42 @@ it('merges when receiving status event', async () => {
     config
   })
 
-  const list = jest.fn(() => ({
-    data: [
-      createPullRequestInfo({ number: 1 })
-    ]
-  }))
+  const graphql = jest.fn(async (query, variables) => {
+    if (variables.refQualifiedName) {
+      return {
+        repository: {
+          ref: {
+            associatedPullRequests: {
+              nodes: [{
+                number: 1,
+                repository: {
+                  name: 'probot-auto-merge',
+                  owner: {
+                    login: 'bobvanderlinden'
+                  }
+                }
+              }]
+            }
+          }
+        }
+      }
+    } else {
+      return github.graphql(query, variables)
+    }
+  }) as any
 
   const app = createApplication({
     appFn,
     logger: createEmptyLogger(),
     github: {
       ...github,
-      pulls: {
-        ...github.pulls,
-        list: list as any
-      }
+      graphql
     } as GitHubAPI
   })
 
   await app.receive(
     createStatusEvent({
-      owner: 'bobvanderlinden',
+      owner: 'owner-of-fork',
       repo: 'probot-auto-merge',
       sha: '123',
       branchName: 'pr-1'
@@ -206,8 +221,26 @@ it('merges when receiving status event', async () => {
 
   await immediate()
 
-  expect(list).toHaveBeenCalled()
-  expect(github.pulls.merge).toHaveBeenCalled()
+  expect(graphql).toHaveBeenCalledWith(
+    expect.anything(), expect.objectContaining({
+      owner: 'owner-of-fork',
+      repo: 'probot-auto-merge',
+      refQualifiedName: 'refs/heads/pr-1'
+    })
+  )
+  expect(graphql).toHaveBeenCalledWith(
+    expect.anything(), expect.objectContaining({
+      owner: 'bobvanderlinden',
+      repo: 'probot-auto-merge',
+      pullRequestNumber: 1
+    })
+  )
+  expect(github.pulls.merge).toHaveBeenCalledWith({
+    merge_method: 'merge',
+    number: 1,
+    owner: 'bobvanderlinden',
+    repo: 'probot-auto-merge'
+  })
 })
 
 it('pending check run', async () => {


### PR DESCRIPTION
Currently status events do not trigger PR reevaluations. This was found @FrittenToni and mentioned here: https://github.com/bobvanderlinden/probot-auto-merge/issues/266#issuecomment-541620313

Whenever status events come in, auto-merge searches the PRs that are related to the branch that is mentioned in the event. It did so by using:

```
      context.github.pulls.list({
        owner: repositoryReference.owner,
        repo: repositoryReference.repo,
        base: branch.name
      })
```

This was wrong, because the `base` of PRs is usually `master` and not the branch of the PR itself. According to [the documentation of the API](https://developer.github.com/v3/pulls/#list-pull-requests) the field `head` should be used. It reads the following:

> Filter pulls by head user or head organization and branch name in the format of user:ref-name or organization:ref-name. For example: github:new-script-format or octocat:test-branch.

In addition, the branch itself could be in a different owner/repo than the pull request itself. Using `github.pulls.list` is therefore not sufficient, as we can only fetch pull requests of the owner/repo of the branch itself.

This PR attempts to solve these issues by using [associatedPullRequests](https://developer.github.com/v4/object/ref/#associatedpullrequests) of the GraphQL GitHub API.