### PR TITLE
Avoid deprecated number field for merge call

### DIFF
--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -317,7 +317,9 @@ async function mergePullRequest (
   // This presses the merge button.
   result(
     await context.github.pulls.merge({
-      ...pullRequestReference,
+      owner: pullRequestReference.owner,
+      repo: pullRequestReference.repo,
+      pull_number: pullRequestReference.number,
       merge_method: config.mergeMethod
     })
   )

--- a/test/pull-request-handler.test.ts
+++ b/test/pull-request-handler.test.ts
@@ -276,7 +276,7 @@ describe('executeAction with action', () => {
       merge_method: 'merge',
       owner: 'bobvanderlinden',
       repo: 'probot-auto-merge',
-      number: 2
+      pull_number: 2
     })
   })
 


### PR DESCRIPTION
Currently octokit is logging deprecation warnings on production about the `number` field being deprecated.
This PR attempts to resolve those warnings.