### PR TITLE
always use static appid for tests

### DIFF
--- a/src/myappid.ts
+++ b/src/myappid.ts
@@ -1,4 +1,7 @@
 function getMyAppId () {
+  if (process.env.NODE_ENV === 'test') {
+    return 1
+  }
   if (process.env.APP_ID) {
     return parseInt(process.env.APP_ID, 10)
   }

--- a/test/status-report.test.ts
+++ b/test/status-report.test.ts
@@ -2,8 +2,6 @@ import { CheckSuite } from './../src/github-models'
 import { createPullRequestInfo, createPullRequestContext, createGithubApi, createCheckRun, createConfig, createCheckSuite, createCommit, createOkResponse } from './mock'
 import { updateStatusReportCheck } from '../src/status-report'
 
-const myappid = 1
-
 function createOtherAppCheckSuite (options?: Partial<CheckSuite>) {
   return createCheckSuite({
     app: {
@@ -19,7 +17,7 @@ function createOtherAppCheckSuite (options?: Partial<CheckSuite>) {
 function createMyCheckSuite (options?: Partial<CheckSuite>) {
   return createCheckSuite({
     app: {
-      databaseId: myappid
+      databaseId: 1
     },
     checkRuns: {
       nodes: [createCheckRun()]
@@ -72,14 +70,6 @@ function mock (options: {
 }
 
 describe('updateStatusReportCheck', () => {
-  beforeAll(() => {
-    jest.mock('../src/myappid', () => myappid)
-  })
-
-  afterAll(() => {
-    jest.unmock('../src/myappid')
-  })
-
   it('when reportStatus is enabled and a check of this app is in pull request, update existing check', async () => {
     const {
       context,


### PR DESCRIPTION
Currently myappid module loads the appid from environment variables, even for tests. Mocking TypeScript modules has shown to be problematic. Therefore it might be easier to avoid `APP_ID` environment variable when in a test environment. In return, we can remove the mocking behaviour.