### PR TITLE
Fix type checking in pull-request-handler test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1686,9 +1686,9 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.18",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.18.tgz",
-      "integrity": "sha512-jcDDXdjTcrQzdN06+TSVsPPqxvsZA/5QkYfIZlq1JMw7FdP5AZylbOc+6B/cuDurctRe+MziUMtQ3xQdrbjqyQ==",
+      "version": "24.0.19",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.19.tgz",
+      "integrity": "sha512-YYiqfSjocv7lk5H/T+v5MjATYjaTMsUkbDnjGqSMoO88jWdtJXJV4ST/7DKZcoMHMBvB2SeSfyOzZfkxXHR5xg==",
       "dev": true,
       "requires": {
         "@types/jest-diff": "*"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",
-    "@types/jest": "^24.0.5",
+    "@types/jest": "^24.0.19",
     "@types/minimatch": "^3.0.3",
     "@types/node": "^12.0.4",
     "@types/p-queue": "^3.0.0",

--- a/test/pull-request-handler.test.ts
+++ b/test/pull-request-handler.test.ts
@@ -225,7 +225,7 @@ describe('getPullRequestPlan', () => {
             name: 'probot-auto-merge'
           }
         },
-        headRef: {
+        headRef: defaultPullRequestInfo.headRef && {
           ...defaultPullRequestInfo.headRef,
           name: 'pr',
           repository: {


### PR DESCRIPTION
Currently the tests do not fully type-check. Type-checking in tests was not enabled, thus this one slipped by. This PR should make all tests type-checkable again.