### PR TITLE
Update Semaphore configuration

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,6 +31,7 @@ blocks:
         commands:
           - checkout
           - cache restore
+          - nvm use
       jobs:
         - name: test
           commands:
@@ -52,6 +53,7 @@ blocks:
           - checkout
           - cache restore
           - artifact pull workflow lib
+          - nvm use
       jobs:
         - name: release
           commands:
@@ -59,6 +61,8 @@ blocks:
       secrets:
         - name: Github Public Repository
         - name: Npm Publish Token
+    skip:
+      when: branch != 'master'
   - name: Building
     dependencies:
       - Installing
@@ -67,6 +71,7 @@ blocks:
         commands:
           - checkout
           - cache restore
+          - nvm use
       jobs:
         - name: build
           commands:
@@ -83,6 +88,7 @@ blocks:
         commands:
           - checkout
           - cache restore
+          - nvm use
       jobs:
         - name: lint
           commands:


### PR DESCRIPTION
Currently a default nodejs version is used for SemaphoreCI. There already is a `.nvmrc` and the documentation states that semaphore will automatically use that version, however, this doesn't seem to be the case as #434 has shown.

This PR will try to always use the nodejs version from `.nvmrc`.

In addition, the release stage currently runs for all branches (including the ones for pull requests). It doesn't do much for those PRs, so we can skip that step.