### PR TITLE
Introduce requiredBodyRegex condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ In the example below, pull requests with the body containing `ok-to-merge` will 
 automatically merged. This also includes `labels: ok-to-merge`, `LABELS: OK-TO-MERGE` or `some more text, but ok-to-merge`, but not `not-ok-to-merge`:
 
 ```yaml
-requiredBodyRegex: ' ok-to-merge'
+requiredBodyRegex: '(^|\s)ok-to-merge($|\s)'
 ```
 
 ### `reportStatus` (default: `false`)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ automatically merged. This also includes `[wip]`, `WIP` or `[WIP]`, but not `swi
 blockingTitleRegex: '\bWIP\b'
 ```
 
+### `requiredBodyRegex` (condition, default: none)
+
+Whenever a required body regular expression is configured, only pull requests that have a body
+matching the configured expression will automatically be merged.
+
+This is useful for forks, that can only create pull request text, no labels.
+
+In the example below, pull requests with the body containing `ok-to-merge` will be
+automatically merged. This also includes `labels: ok-to-merge`, `LABELS: OK-TO-MERGE` or `some more text, but ok-to-merge`, but not `not-ok-to-merge`:
+
+```yaml
+requiredBodyRegex: ' ok-to-merge'
+```
+
 ### `reportStatus` (default: `false`)
 
 The status of the auto-merge process will be shown in each PR as a [check](https://help.github.com/articles/about-status-checks/). This can be especially useful to find out why a PR is not being merged automatically.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ In the example below, pull requests with the body containing `ok-to-merge` will 
 automatically merged. This also includes `labels: ok-to-merge`, `LABELS: OK-TO-MERGE` or `some more text, but ok-to-merge`, but not `not-ok-to-merge`:
 
 ```yaml
-requiredBodyRegex: '(^|\s)ok-to-merge($|\s)'
+requiredBodyRegex: '(^|\\s)ok-to-merge($|\\s)'
 ```
 
 ### `reportStatus` (default: `false`)

--- a/src/conditions/index.ts
+++ b/src/conditions/index.ts
@@ -9,6 +9,7 @@ import minimumApprovals from './minimumApprovals'
 import open from './open'
 // import requiredChecks from './requiredChecks'
 import requiredLabels from './requiredLabels'
+import requiredBody from './requiredBody'
 
 export const conditions = {
   blockingChecks,
@@ -19,6 +20,7 @@ export const conditions = {
   minimumApprovals,
   open,
   // requiredChecks,
+  requiredBody,
   requiredLabels
 }
 

--- a/src/conditions/requiredBody.ts
+++ b/src/conditions/requiredBody.ts
@@ -22,6 +22,6 @@ export default function hasRequiredBody (
 
   return {
     status: 'fail',
-    message: `Required words were not found in body (${pullRequestInfo.body})`
+    message: 'Required regular expression did not match body'
   }
 }

--- a/src/conditions/requiredBody.ts
+++ b/src/conditions/requiredBody.ts
@@ -6,7 +6,7 @@ export default function hasRequiredLabels (
   config: ConditionConfig,
   pullRequestInfo: PullRequestInfo
 ): ConditionResult {
-  if (config.requiredBodyRegex === undefined) {
+  if (!config.requiredBodyRegex) {
     return {
       status: 'success'
     }

--- a/src/conditions/requiredBody.ts
+++ b/src/conditions/requiredBody.ts
@@ -2,7 +2,7 @@ import { ConditionConfig } from '../config'
 import { PullRequestInfo } from '../models'
 import { ConditionResult } from '../condition'
 
-export default function hasRequiredLabels (
+export default function hasRequiredBody (
   config: ConditionConfig,
   pullRequestInfo: PullRequestInfo
 ): ConditionResult {

--- a/src/conditions/requiredBody.ts
+++ b/src/conditions/requiredBody.ts
@@ -1,0 +1,27 @@
+import { ConditionConfig } from '../config'
+import { PullRequestInfo } from '../models'
+import { ConditionResult } from '../condition'
+
+export default function hasRequiredLabels (
+  config: ConditionConfig,
+  pullRequestInfo: PullRequestInfo
+): ConditionResult {
+  if (config.requiredBodyRegex === undefined) {
+    return {
+      status: 'success'
+    }
+  }
+
+  const regexObj = new RegExp(config.requiredBodyRegex, 'ig')
+
+  if (regexObj.test(pullRequestInfo.body)) {
+    return {
+      status: 'success'
+    }
+  }
+
+  return {
+    status: 'fail',
+    message: `Required words were not found in body (${pullRequestInfo.body})`
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ export type ConditionConfig = {
   maxRequestedChanges: { [key in CommentAuthorAssociation]?: number },
   requiredLabels: string[],
   blockingLabels: string[],
+  requiredBodyRegex: string | undefined
   blockingTitleRegex: string | undefined
 }
 
@@ -50,7 +51,8 @@ export const defaultRuleConfig: ConditionConfig = {
   },
   blockingLabels: [],
   requiredLabels: [],
-  blockingTitleRegex: undefined
+  blockingTitleRegex: undefined,
+  requiredBodyRegex: undefined
 }
 
 export const defaultConfig: Config = {
@@ -77,7 +79,8 @@ const conditionConfigDecoder: Decoder<ConditionConfig> = object({
   maxRequestedChanges: reviewConfigDecover,
   requiredLabels: array(string()),
   blockingLabels: array(string()),
-  blockingTitleRegex: optional(string())
+  blockingTitleRegex: optional(string()),
+  requiredBodyRegex: optional(string())
 })
 
 const configDecoder: Decoder<Config> = object({
@@ -87,6 +90,7 @@ const configDecoder: Decoder<Config> = object({
   requiredLabels: array(string()),
   blockingLabels: array(string()),
   blockingTitleRegex: optional(string()),
+  requiredBodyRegex: optional(string()),
   updateBranch: boolean(),
   deleteBranchAfterMerge: boolean(),
   reportStatus: boolean(),

--- a/test/conditions/requiredBody.test.ts
+++ b/test/conditions/requiredBody.test.ts
@@ -1,7 +1,7 @@
 import requiredBody from '../../src/conditions/requiredBody'
 import { createPullRequestInfo, createConditionConfig } from '../mock'
 
-describe('open', () => {
+describe('requiredBody', () => {
   it('returns success with empty body and no configuration', async () => {
     const result = requiredBody(
       createConditionConfig(),

--- a/test/conditions/requiredBody.test.ts
+++ b/test/conditions/requiredBody.test.ts
@@ -1,0 +1,52 @@
+import requiredBody from '../../src/conditions/requiredBody'
+import { createPullRequestInfo, createConditionConfig } from '../mock'
+
+describe('open', () => {
+  it('returns success with empty body and no configuration', async () => {
+    const result = requiredBody(
+      createConditionConfig(),
+      createPullRequestInfo({
+        body: ''
+      })
+    )
+    expect(result.status).toBe('success')
+  })
+
+  it('returns fail with body not in configuration', async () => {
+    const result = requiredBody(
+      createConditionConfig({
+        requiredBodyRegex: 'required-body'
+      }),
+      createPullRequestInfo({
+        body: 'unrelated'
+      })
+    )
+    expect(result.status).toBe('fail')
+  })
+
+  it('returns success with body in configuration', async () => {
+    const result = requiredBody(
+      createConditionConfig({
+        requiredBodyRegex: 'required-body'
+      }),
+      createPullRequestInfo({
+        body: 'required-body'
+      })
+    )
+    expect(result.status).toBe('success')
+  })
+
+  it('returns success with longer body with body in configuration', async () => {
+    const result = requiredBody(
+      createConditionConfig({
+        requiredBodyRegex: 'required-body'
+      }),
+      createPullRequestInfo({
+        body: `This is a long multi-line pull request description
+        
+labels: required-body`
+      })
+    )
+    expect(result.status).toBe('success')
+  })
+})

--- a/test/conditions/requiredBody.test.ts
+++ b/test/conditions/requiredBody.test.ts
@@ -49,4 +49,21 @@ labels: required-body`
     )
     expect(result.status).toBe('success')
   })
+  it('returns success with longer body with body regex in configuration', async () => {
+    const result = requiredBody(
+      createConditionConfig({
+        requiredBodyRegex: '\\w+:\\s`required-body`$'
+      }),
+      createPullRequestInfo({
+        body: `This is a long multi-line pull request description
+that includes \`escaped-characters\`
+with multiline codeblock:
+\`\`\`
+  echo "hello"
+\`\`\`
+labels: \`required-body\``
+      })
+    )
+    expect(result.status).toBe('success')
+  })
 })


### PR DESCRIPTION
Not sure that's a good idea, but there are some tools out there (in our case scala-steward), which cannot add labels to pull requests (see https://github.com/fthomas/scala-steward/issues/404). In their case, they append labels to the body of a pull request.