### PR TITLE
Process 'status' events when PRs are created from fork

### DIFF
--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -178,13 +178,14 @@ it('merges when receiving status event', async () => {
   })
 
   const graphql = jest.fn(async (query, variables) => {
-    if (variables.refQualifiedName) {
+    if (variables.sha) {
       return {
         repository: {
-          ref: {
+          object: {
             associatedPullRequests: {
               nodes: [{
                 number: 1,
+                state: 'OPEN',
                 repository: {
                   name: 'probot-auto-merge',
                   owner: {
@@ -214,7 +215,7 @@ it('merges when receiving status event', async () => {
     createStatusEvent({
       owner: 'owner-of-fork',
       repo: 'probot-auto-merge',
-      sha: '123',
+      sha: '916200ea5344364220b57fa6412f0f99a3638356',
       branchName: 'pr-1'
     })
   )
@@ -225,7 +226,7 @@ it('merges when receiving status event', async () => {
     expect.anything(), expect.objectContaining({
       owner: 'owner-of-fork',
       repo: 'probot-auto-merge',
-      refQualifiedName: 'refs/heads/pr-1'
+      sha: '916200ea5344364220b57fa6412f0f99a3638356'
     })
   )
   expect(graphql).toHaveBeenCalledWith(


### PR DESCRIPTION
Hello!
Seems like I have found a bug(?): when PR is created from a fork, it doesn't handle `status` events.
So, following scenario won't work:
1) Fork created
2) Feature branch in fork created, commit added, PR created against upstream master branch
3) CI tests are running, bot has validated all requirements and is waiting for CI tests to be reported (when branch protection rules are applied, e.g. no merge allowed unless CI tests passed)
4) `Status` event received by bot once CI tests passed, but bot is ignoring this event, as `branches` array is empty (https://github.com/bobvanderlinden/probot-auto-merge/blob/master/src/index.ts#L131).
I've found that `branches` array is always empty when PR is created from a fork.

So I decided to try get associated PRs for commit sha, not a branch.


Note, I'm not a typescript developer, this "iteration" thing around `iter` variable looks awful, I know, but I can't get a rid of it.
Feel free to push changes to this branch if you have ideas.

In addition, lmk if you think it is better to remove `debug`s from the code.
I think it is fine to leave it since debug level is not default anyway, so it gives some information what happened and why. 

Thank you!