### PR TITLE
Fix merging pull requests from forks

### DIFF
--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -177,27 +177,24 @@ it('merges when receiving status event', async () => {
     config
   })
 
-  const graphql = jest.fn(async (query, variables) => {
-    if (variables.refQualifiedName) {
-      return {
-        repository: {
-          ref: {
-            associatedPullRequests: {
-              nodes: [{
-                number: 1,
-                repository: {
-                  name: 'probot-auto-merge',
-                  owner: {
-                    login: 'bobvanderlinden'
-                  }
+  const graphql = jest.fn(async (query, variables) => github.graphql(query, variables)).mockResolvedValueOnce({
+    repository: {
+      pullRequests: {
+        edges: [
+          {
+            node: {
+              number: 1,
+              headRefOid: '123',
+              repository: {
+                name: 'probot-auto-merge',
+                owner: {
+                  login: 'bobvanderlinden'
                 }
-              }]
+              }
             }
           }
-        }
+        ]
       }
-    } else {
-      return github.graphql(query, variables)
     }
   }) as any
 
@@ -224,8 +221,7 @@ it('merges when receiving status event', async () => {
   expect(graphql).toHaveBeenCalledWith(
     expect.anything(), expect.objectContaining({
       owner: 'owner-of-fork',
-      repo: 'probot-auto-merge',
-      refQualifiedName: 'refs/heads/pr-1'
+      repo: 'probot-auto-merge'
     })
   )
   expect(graphql).toHaveBeenCalledWith(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -177,26 +177,27 @@ it('merges when receiving status event', async () => {
     config
   })
 
-  const graphql = jest.fn(async (query, variables) => github.graphql(query, variables)).mockResolvedValueOnce({
-    repository: {
-      pullRequests: {
-        edges: [
-          {
-            node: {
-              number: 1,
-              headRefOid: '123',
-              repository: {
-                name: 'probot-auto-merge',
-                owner: {
-                  login: 'bobvanderlinden'
+  const graphql = jest.fn(async (query, variables) => github.graphql(query, variables))
+    .mockResolvedValueOnce({
+      repository: {
+        pullRequests: {
+          edges: [
+            {
+              node: {
+                number: 1,
+                headRefOid: '123',
+                repository: {
+                  name: 'probot-auto-merge',
+                  owner: {
+                    login: 'bobvanderlinden'
+                  }
                 }
               }
             }
-          }
-        ]
+          ]
+        }
       }
-    }
-  }) as any
+    }) as any
 
   const app = createApplication({
     appFn,


### PR DESCRIPTION
Before this change merging pull requests from forks
is broken because the branches array in the status
event was empty and the graphql query did return nothing.

This pr proposes using the sha field from the status
event and finding this sha hash  in all open PRs.
The commit is assigned to the PR if it's the leading
commit of this branch. (headRefOid).
It also simplifies the graphql query and add the
master restriction to the query.

The only assumption I took is that we either find the PR in
the 100 last updated PRs. If assumption is unreasonable
we would need to iterate over the whole PR set.