### PR TITLE
Add requiredTitleRegex condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ automatically merged. This also includes `[wip]`, `WIP` or `[WIP]`, but not `swi
 blockingTitleRegex: '\bWIP\b'
 ```
 
+### `requiredTitleRegex` (condition, default: none)
+
+Whenever a required title regular expression is configured, only pull requests that have a title
+matching the configured expression will automatically be merged.
+
+This is useful for forks, that can only create pull request text, no labels.
+
+In the example below, pull requests with the title containing `MERGE` will be
+automatically merged. This also includes This also includes `[merge]`, `MERGE` or `[MERGE]`, but not `submerge`:
+
+```yaml
+requiredTitleRegex: '\bMERGE\b'
+```
+
 ### `blockingBodyRegex` (condition, default: none)
 
 Whenever a blocking body regular expression is configured, pull requests that have a body

--- a/auto-merge.example.yml
+++ b/auto-merge.example.yml
@@ -64,6 +64,10 @@ blockingLabels:
 requiredLabels:
 - merge
 
+# Pull requests will only be automatically merged if there is a match between the regular expression
+# and its title
+requiredTitleRegex: '\bmerge\b'
+
 # Automatic merges will be blocked if there is a match between the regular expression and title
 blockingTitleRegex: '\bwip\b'
 

--- a/src/conditions/index.ts
+++ b/src/conditions/index.ts
@@ -11,6 +11,7 @@ import open from './open'
 // import requiredChecks from './requiredChecks'
 import requiredLabels from './requiredLabels'
 import requiredBody from './requiredBody'
+import requiredTitle from './requiredTitle'
 
 export const conditions = {
   blockingBody,
@@ -23,7 +24,8 @@ export const conditions = {
   open,
   // requiredChecks,
   requiredBody,
-  requiredLabels
+  requiredLabels,
+  requiredTitle
 }
 
 export type Conditions = typeof conditions

--- a/src/conditions/requiredTitle.ts
+++ b/src/conditions/requiredTitle.ts
@@ -1,0 +1,26 @@
+import { ConditionConfig } from './../config'
+import { ConditionResult } from '../condition'
+import { PullRequestInfo } from '../models'
+
+export default function doesNotHaveRequiredTitle (
+  config: ConditionConfig,
+  pullRequestInfo: PullRequestInfo
+): ConditionResult {
+  if (config.requiredTitleRegex === undefined) {
+    return {
+      status: 'success'
+    }
+  }
+
+  const regexObj = new RegExp(config.requiredTitleRegex, 'i')
+
+  if (regexObj.test(pullRequestInfo.title)) {
+    return {
+      status: 'success'
+    }
+  }
+  return {
+    status: 'fail',
+    message: `Required regular expression did not match title (${pullRequestInfo.title})`
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ export type ConditionConfig = {
   blockingBodyRegex: string | undefined
   requiredBodyRegex: string | undefined
   blockingTitleRegex: string | undefined
+  requiredTitleRegex: string | undefined
 }
 
 export type Config = {
@@ -54,6 +55,7 @@ export const defaultRuleConfig: ConditionConfig = {
   requiredLabels: [],
   blockingTitleRegex: undefined,
   blockingBodyRegex: undefined,
+  requiredTitleRegex: undefined,
   requiredBodyRegex: undefined
 }
 
@@ -83,6 +85,7 @@ const conditionConfigDecoder: Decoder<ConditionConfig> = object({
   blockingLabels: array(string()),
   blockingTitleRegex: optional(string()),
   blockingBodyRegex: optional(string()),
+  requiredTitleRegex: optional(string()),
   requiredBodyRegex: optional(string())
 })
 
@@ -94,6 +97,7 @@ const configDecoder: Decoder<Config> = object({
   blockingLabels: array(string()),
   blockingTitleRegex: optional(string()),
   blockingBodyRegex: optional(string()),
+  requiredTitleRegex: optional(string()),
   requiredBodyRegex: optional(string()),
   updateBranch: boolean(),
   deleteBranchAfterMerge: boolean(),

--- a/test/conditions/requiredTitle.test.ts
+++ b/test/conditions/requiredTitle.test.ts
@@ -37,7 +37,7 @@ describe('requiredTitle', () => {
     expect(result.status).toBe('success')
   })
 
-  it('returns success if there is a partial match in title', async () => {
+  it('returns success if there is a regex match in title', async () => {
     const result = requiredTitle(
       createConditionConfig({
         requiredTitleRegex: 'mer.+shiny'

--- a/test/conditions/requiredTitle.test.ts
+++ b/test/conditions/requiredTitle.test.ts
@@ -1,0 +1,51 @@
+import { createConditionConfig, createPullRequestInfo } from '../mock'
+
+import requiredTitle from '../../src/conditions/requiredTitle'
+
+describe('requiredTitle', () => {
+  it('returns success if with default configuration(undefined)', async () => {
+    const result = requiredTitle(
+      createConditionConfig(),
+      createPullRequestInfo({
+        title: '[MERGE] Shiny new feature'
+      })
+    )
+    expect(result.status).toBe('success')
+  })
+
+  it('returns fail if there is no match in title', async () => {
+    const result = requiredTitle(
+      createConditionConfig({
+        requiredTitleRegex: 'merge'
+      }),
+      createPullRequestInfo({
+        title: 'Add some feature'
+      })
+    )
+    expect(result.status).toBe('fail')
+  })
+
+  it('returns success if there is a match in title', async () => {
+    const result = requiredTitle(
+      createConditionConfig({
+        requiredTitleRegex: 'merge'
+      }),
+      createPullRequestInfo({
+        title: '[MERGE] Shiny new feature'
+      })
+    )
+    expect(result.status).toBe('success')
+  })
+
+  it('returns success if there is a partial match in title', async () => {
+    const result = requiredTitle(
+      createConditionConfig({
+        requiredTitleRegex: 'mer.+shiny'
+      }),
+      createPullRequestInfo({
+        title: '[MERGE] Shiny new feature'
+      })
+    )
+    expect(result.status).toBe('success')
+  })
+})


### PR DESCRIPTION
The `requiredTitleRegex` condition is a complementary condition for `blockingTitleRegex`.

It can be used to only merge pull requests with a title matching the configured regular expression, similar to the `requiredBodyRegex` condition.