### PR TITLE
Add blockingBodyRegex condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,21 @@ automatically merged. This also includes `[wip]`, `WIP` or `[WIP]`, but not `swi
 blockingTitleRegex: '\bWIP\b'
 ```
 
+### `blockingBodyRegex` (condition, default: none)
+
+Whenever a blocking body regular expression is configured, pull requests that have a body
+matching the configured expression will not be automatically merged.
+
+This is useful whenever pull requests with a certain string in their body need to be skipped.
+
+In the example below, pull requests with the body containing `do-not-merge` will not be
+automatically merged. This also includes `labels: do-not-merge`, `LABELS: DO-NOT-MERGE` or `some more text, but do-not-merge`,
+but not `do-not-merge-just-kidding`:
+
+```yaml
+blockingBodyRegex: '(^|\\s)do-not-merge($|\\s)'
+```
+
 ### `requiredBodyRegex` (condition, default: none)
 
 Whenever a required body regular expression is configured, only pull requests that have a body

--- a/auto-merge.example.yml
+++ b/auto-merge.example.yml
@@ -66,3 +66,6 @@ requiredLabels:
 
 # Automatic merges will be blocked if there is a match between the regular expression and title
 blockingTitleRegex: '\bwip\b'
+
+# Automatic merges will be blocked if there is a match between the regular expression and body
+blockingBodyRegex: '\bDo not merge\b'

--- a/src/conditions/blockingBody.ts
+++ b/src/conditions/blockingBody.ts
@@ -1,0 +1,26 @@
+import { ConditionConfig } from '../config'
+import { ConditionResult } from '../condition'
+import { PullRequestInfo } from '../models'
+
+export default function hasBlockingBody (
+  config: ConditionConfig,
+  pullRequestInfo: PullRequestInfo
+): ConditionResult {
+  if (!config.blockingBodyRegex) {
+    return {
+      status: 'success'
+    }
+  }
+
+  const regexObj = new RegExp(config.blockingBodyRegex, 'ig')
+
+  if (regexObj.test(pullRequestInfo.body)) {
+    return {
+      status: 'fail',
+      message: 'Blocking regular expression matched body'
+    }
+  }
+  return {
+    status: 'success'
+  }
+}

--- a/src/conditions/index.ts
+++ b/src/conditions/index.ts
@@ -1,5 +1,6 @@
 import { ConditionResult } from './../condition'
 import { keysOf } from '../utils'
+import blockingBody from './blockingBody'
 import blockingChecks from './blockingChecks'
 import blockingLabels from './blockingLabels'
 import blockingTitle from './blockingTitle'
@@ -12,6 +13,7 @@ import requiredLabels from './requiredLabels'
 import requiredBody from './requiredBody'
 
 export const conditions = {
+  blockingBody,
   blockingChecks,
   blockingLabels,
   blockingTitle,

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ export type ConditionConfig = {
   maxRequestedChanges: { [key in CommentAuthorAssociation]?: number },
   requiredLabels: string[],
   blockingLabels: string[],
+  blockingBodyRegex: string | undefined
   requiredBodyRegex: string | undefined
   blockingTitleRegex: string | undefined
 }
@@ -52,6 +53,7 @@ export const defaultRuleConfig: ConditionConfig = {
   blockingLabels: [],
   requiredLabels: [],
   blockingTitleRegex: undefined,
+  blockingBodyRegex: undefined,
   requiredBodyRegex: undefined
 }
 
@@ -80,6 +82,7 @@ const conditionConfigDecoder: Decoder<ConditionConfig> = object({
   requiredLabels: array(string()),
   blockingLabels: array(string()),
   blockingTitleRegex: optional(string()),
+  blockingBodyRegex: optional(string()),
   requiredBodyRegex: optional(string())
 })
 
@@ -90,6 +93,7 @@ const configDecoder: Decoder<Config> = object({
   requiredLabels: array(string()),
   blockingLabels: array(string()),
   blockingTitleRegex: optional(string()),
+  blockingBodyRegex: optional(string()),
   requiredBodyRegex: optional(string()),
   updateBranch: boolean(),
   deleteBranchAfterMerge: boolean(),

--- a/test/conditions/blockingBody.test.ts
+++ b/test/conditions/blockingBody.test.ts
@@ -1,0 +1,70 @@
+import { createConditionConfig, createPullRequestInfo } from '../mock'
+
+import blockingBody from '../../src/conditions/blockingBody'
+
+describe('blockingBody', () => {
+  it('returns success with empty body and no configuration', async () => {
+    const result = blockingBody(
+      createConditionConfig(),
+      createPullRequestInfo({
+        body: ''
+      })
+    )
+    expect(result.status).toBe('success')
+  })
+
+  it('returns success with regular expression not matching body', async () => {
+    const result = blockingBody(
+      createConditionConfig({
+        blockingBodyRegex: 'blocked-body'
+      }),
+      createPullRequestInfo({
+        body: 'unrelated'
+      })
+    )
+    expect(result.status).toBe('success')
+  })
+
+  it('returns fail with regular expression matching body', async () => {
+    const result = blockingBody(
+      createConditionConfig({
+        blockingBodyRegex: 'blocked-body'
+      }),
+      createPullRequestInfo({
+        body: 'A short test with blocked-body included'
+      })
+    )
+    expect(result.status).toBe('fail')
+  })
+
+  it('returns fail with longer body matching regular expression', async () => {
+    const result = blockingBody(
+      createConditionConfig({
+        blockingBodyRegex: 'blocked-body'
+      }),
+      createPullRequestInfo({
+        body: `This is a long multi-line pull request description
+
+labels: blocked-body`
+      })
+    )
+    expect(result.status).toBe('fail')
+  })
+  it('returns fail with longer body with more complicated matching regular expression', async () => {
+    const result = blockingBody(
+      createConditionConfig({
+        blockingBodyRegex: '\\w+:\\s`blocked-body`$'
+      }),
+      createPullRequestInfo({
+        body: `This is a long multi-line pull request description
+that includes \`escaped-characters\`
+with multiline codeblock:
+\`\`\`
+  echo "hello"
+\`\`\`
+labels: \`blocked-body\``
+      })
+    )
+    expect(result.status).toBe('fail')
+  })
+})


### PR DESCRIPTION
The `blockingBodyRegex` condition is a complementary condition for `requiredBodyRegex`.

It can be used to prevent merging pull requests with a body matching the configured regular expression, similar to the `blockingTitleRegex` condition.