### PR TITLE
improve the description for MergeStateStatus.BLOCKED

### DIFF
--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -202,7 +202,7 @@ export function getPullRequestPlan (
     case MergeStateStatus.BLOCKED:
       return {
         code: 'blocked',
-        message: 'The pull request is blocked by a failing or missing check.',
+        message: 'Merging the pull request is blocked by branch protection rules.\n\nPlease make sure probot-auto-merge is part of "Restrict who can push to matching branches" under Branch protection rules.',
         actions: []
       }
     case MergeStateStatus.DIRTY:

--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -205,7 +205,7 @@ export function getPullRequestPlan (
       // See: https://docs.github.com/en/graphql/reference/enums#mergestatestatus
       return {
         code: 'blocked',
-        message: 'Merging the pull request is blocked by branch protection rules.\n\nPlease make sure probot-auto-merge is part of "Restrict who can push to matching branches" under Branch protection rules.',
+        message: `Merging the pull request is blocked by branch protection rules. Please make sure probot-auto-merge has permission to push to \`${pullRequestInfo.baseRef.name}\` under the "Restrict who can push to matching branches" section the branch protection rules.`,
         actions: []
       }
     case MergeStateStatus.DIRTY:

--- a/src/pull-request-handler.ts
+++ b/src/pull-request-handler.ts
@@ -200,6 +200,9 @@ export function getPullRequestPlan (
         }
       }
     case MergeStateStatus.BLOCKED:
+      // The GitHub documentation for the status BLOCKED is rather vague.
+      // We presume that branch protection rules is likely the cause of BLOCKED status.
+      // See: https://docs.github.com/en/graphql/reference/enums#mergestatestatus
       return {
         code: 'blocked',
         message: 'Merging the pull request is blocked by branch protection rules.\n\nPlease make sure probot-auto-merge is part of "Restrict who can push to matching branches" under Branch protection rules.',

--- a/test/pull-request-handler.test.ts
+++ b/test/pull-request-handler.test.ts
@@ -4,7 +4,7 @@ import { conditions, ConditionName } from './../src/conditions/'
 import { ConditionResult } from './../src/condition'
 import { PullRequestInfo } from './../src/models'
 import { getPullRequestPlan, executeAction } from '../src/pull-request-handler'
-import { createHandlerContext, createPullRequestInfo, createConfig, defaultPullRequestInfo, createGithubApi, createPullRequestContext, createOkResponse } from './mock'
+import { createHandlerContext, createPullRequestInfo, createConfig, defaultPullRequestInfo, createGithubApi, createPullRequestContext, createOkResponse, createRef } from './mock'
 import { mapObject } from '../src/utils'
 import { MergeStateStatus } from '../src/query.graphql'
 
@@ -120,6 +120,27 @@ describe('getPullRequestPlan', () => {
       createPullRequestStatus()
     )
     expect(plan.actions).toEqual(['update_branch', 'reschedule'])
+  })
+
+  it('emit error when pull request merge status is BLOCKED', async () => {
+    const plan = getPullRequestPlan(
+      createHandlerContext({
+        config: createConfig()
+      }),
+      createPullRequestInfo({
+        baseRef: createRef({
+          name: 'main'
+        }),
+        headRef: headRefInSameRepository,
+        mergeStateStatus: MergeStateStatus.BLOCKED
+      }),
+      createPullRequestStatus()
+    )
+    expect(plan).toEqual({
+      code: 'blocked',
+      actions: [],
+      message: 'Merging the pull request is blocked by branch protection rules. Please make sure probot-auto-merge has permission to push to `main` under the "Restrict who can push to matching branches" section the branch protection rules.'
+    })
   })
 
   it('not update branch when pull request is up-to-date and update-branch is disabled', async () => {


### PR DESCRIPTION
Resolves https://github.com/bobvanderlinden/probot-auto-merge/issues/805

Branch protection rules are likely the main reason GitHub responds with `MergeStateStatus.BLOCKED`. It would be nice to explain this to the user so they can update their branch protection rules to allow auto-merge to merge.

Ping @rogerluan