### PR TITLE
fix: avoid emitting errors when no configuration is available

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import { Context } from 'probot'
 import getConfig from 'probot-config'
 import { Decoder, object, string, optional, number, boolean, array, oneOf, constant } from '@mojotech/json-type-validation'
 
-class ConfigNotFoundError extends Error {
+export class ConfigNotFoundError extends Error {
   constructor (
     public readonly filePath: string
   ) {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -126,9 +126,10 @@ it('not enough approval reviews', async () => {
 })
 
 it('no configuration should not schedule any pull request', async () => {
+  const schedulePullRequestTrigger = jest.fn()
   jest.mock('../src/pull-request-handler', () => {
     return {
-      schedulePullRequestTrigger: jest.fn()
+      schedulePullRequestTrigger
     }
   })
 
@@ -144,15 +145,15 @@ it('no configuration should not schedule any pull request', async () => {
     github
   })
 
-  expect(
-    app.receive(
-      createPullRequestOpenedEvent({
-        owner: 'bobvanderlinden',
-        repo: 'probot-auto-merge',
-        number: 1
-      })
-    )
-  ).rejects.toHaveProperty('message', "Configuration file '.github/auto-merge.yml' not found")
+  app.receive(
+    createPullRequestOpenedEvent({
+      owner: 'bobvanderlinden',
+      repo: 'probot-auto-merge',
+      number: 1
+    })
+  )
+
+  expect(schedulePullRequestTrigger).toBeCalledTimes(0)
 })
 
 it('merges when receiving status event', async () => {


### PR DESCRIPTION
Currently whenever a repository does not have a (valid) auto-merge configuration, `ConfigNotFoundError` and `ConfigValidationError` is thrown. This is functionally fine, but Sentry is getting overloaded with these error reports without them adding much value. Functionally auto-merge operates like it should without throwing such errors, so it's best to just ignore them.